### PR TITLE
exporter: reorder link libraries for building

### DIFF
--- a/eunomia-exporter/build.rs
+++ b/eunomia-exporter/build.rs
@@ -15,10 +15,10 @@ fn main() {
     println!("cargo:rustc-link-lib=dylib=stdc++");
 
     // Tell cargo to tell rustc to link
+    println!("cargo:rustc-link-lib=static=eunomia");
     println!("cargo:rustc-link-lib=static=bpf");
     println!("cargo:rustc-link-lib=static=elf");
     println!("cargo:rustc-link-lib=static=z");
-    println!("cargo:rustc-link-lib=static=eunomia");
 
     // Tell cargo to invalidate the built crate whenever the wrapper changes
     println!("cargo:rerun-if-changed=wrapper.h");


### PR DESCRIPTION
The linker will link later objects to earlier objects. Since the `libeunomia` depends on the `libbpf`, the `libeunomia` should be in front of `libbpf`.

Fixes: #31

Signed-off-by: Yu Li \<liyu.yukiteru@bytedance.com\>