### PR TITLE
ecc: add optional path for `eunomia_home`

### DIFF
--- a/compiler/cmd/src/config.rs
+++ b/compiler/cmd/src/config.rs
@@ -56,6 +56,7 @@ pub struct CompileOptions {
 }
 
 static EUNOMIA_HOME_ENV: &str = "EUNOMIA_HOME";
+static FHS_EUNOMIA_HOME_ENTRY: &str = "/usr/share/eunomia";
 
 /// Get home directory from env
 pub fn get_eunomia_home() -> Result<String> {
@@ -67,7 +68,13 @@ pub fn get_eunomia_home() -> Result<String> {
                 let home = home.join(".eunomia");
                 Ok(home.to_str().unwrap().to_string())
             }
-            None => Err(anyhow::anyhow!("HOME is not found")),
+            None => {
+                if path::Path::new(FHS_EUNOMIA_HOME_ENTRY).exists() {
+                    Ok(FHS_EUNOMIA_HOME_ENTRY.to_string())
+                } else {
+                    Err(anyhow::anyhow!("HOME is not found"))
+                }
+            }
         },
     }
 }

--- a/compiler/cmd/src/config.rs
+++ b/compiler/cmd/src/config.rs
@@ -255,4 +255,35 @@ mod test {
         let source_path = "/xxx/test.c";
         let _ = get_base_dir_include(source_path).unwrap_err();
     }
+
+    #[test]
+    fn test_get_eunomia_home() {
+        let eunomia_home_from_env = std::env::var(EUNOMIA_HOME_ENV);
+        let eunomia_home_from_home = home::home_dir().unwrap();
+
+        match eunomia_home_from_env {
+            Ok(path) => assert_eq!(get_eunomia_home().unwrap(), path),
+            Err(_) => {
+                if get_eunomia_home().is_err() {
+                    assert!(true)
+                }
+
+                if eunomia_home_from_home.exists() {
+                    assert_eq!(
+                        get_eunomia_home().unwrap(),
+                        eunomia_home_from_home
+                            .join(".eunomia")
+                            .into_os_string()
+                            .into_string()
+                            .unwrap()
+                    );
+                } else {
+                    assert_eq!(
+                        get_eunomia_home().unwrap(),
+                        FHS_EUNOMIA_HOME_ENTRY.to_string()
+                    )
+                }
+            }
+        }
+    }
 }

--- a/compiler/cmd/src/config.rs
+++ b/compiler/cmd/src/config.rs
@@ -234,13 +234,6 @@ mod test {
     use clap::Parser;
 
     #[test]
-    fn test_create_eunomia_home() {
-        create_eunomia_home().unwrap();
-        let home = get_eunomia_home().unwrap();
-        assert!(Path::new(&home).exists());
-    }
-
-    #[test]
     fn test_parse_args() {
         let _ = CompileOptions::parse_from(&["ecc", "test.c"]);
         let _ = CompileOptions::parse_from(&["ecc", "test.c", "-o", "test.o"]);
@@ -285,5 +278,12 @@ mod test {
                 }
             }
         }
+    }
+
+    #[test]
+    fn test_create_eunomia_home() {
+        create_eunomia_home().unwrap();
+        let home = get_eunomia_home().unwrap();
+        assert!(Path::new(&home).exists());
     }
 }


### PR DESCRIPTION
## Description

To improve compatibility when packaging on FHS Linux distros, add optional `/usr/share/eunomia` as eunomia home.

No additional dependencies introduced.

## Type of change

- [x] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

- [x] Tested compilation of `ecc` `bpftool` `ecli` on openEuler 22.09, NixOS, Rocky Linux 9.1, Debian 11
- [x] Tested basic functionality of all binary files with running `example/bpftool/minimal`
- [x] Passed testes of ecli and ecc with `make test`
* NixOS have not tested to run minimal example and test with Makefile yet due to file hierarchy not compatible.


**Firmware & toolchain version & Hardware**
- openEuler 22.09
5.10.0-106.18.0.68.oe2209.x86_64
clang version 12.0.1
cargo 1.60.0
x86_64 KVM

- NixOS 23.05.20230113.fa22ac8 (Stoat)
6.1.3
clang version 14.0.6
cargo 1.68.0-nightly (d992ab4e9 2023-01-10)
5900X

- Rocky Linux 9.1 
5.14.0-162.6.1.el9_1.x86_64
clang version 14.0.6 (Red Hat 14.0.6-1.el9)
cargo 1.66.1 (ad779e08b 2023-01-10)
x86_64 KVM

- Debian GNU/Linux 11 (bullseye)
5.10.0-19-amd64
Debian clang version 11.0.1-2
cargo 1.66.1 (ad779e08b 2023-01-10)
J1900

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~ trival changes
- [ ] ~~I have made corresponding changes to the documentation~~ trival changes
- [x] My changes generate no new warnings
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~ trival changes
- [x] New and existing unit tests pass locally with my changes
- [ ] ~~Any dependent changes have been merged and published in downstream modules~~ no dependencies changes
- [x] I have checked my code and corrected any misspellings
