### PR TITLE
ecc: use temp dir as workspace

### DIFF
--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -78,6 +78,7 @@ install:
 test:
 	cargo install clippy-sarif sarif-fmt grcov
 	rustup component add llvm-tools-preview
+	cp -r cmd/test /tmp
 	cd cmd && CARGO_INCREMENTAL=0 RUSTFLAGS="-Cinstrument-coverage -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off" RUSTDOCFLAGS="-Cpanic=abort" cargo test
 	cd cmd && grcov . --binary-path ./target/debug/ --llvm -s . -t html --branch --ignore-not-existing -o ./coverage/
 	cd cmd && grcov . --binary-path ./target/debug/ --llvm -s . -t lcov --branch --ignore-not-existing -o ./lcov.info

--- a/compiler/cmd/Cargo.lock
+++ b/compiler/cmd/Cargo.lock
@@ -205,7 +205,17 @@ name = "eunomia-rs"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "fastrand",
  "home",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+dependencies = [
+ "instant",
 ]
 
 [[package]]
@@ -293,6 +303,15 @@ checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
  "hashbrown",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]

--- a/compiler/cmd/src/compile_bpf.rs
+++ b/compiler/cmd/src/compile_bpf.rs
@@ -19,17 +19,17 @@ fn parse_json_output(output: &str) -> Result<Value> {
 }
 
 /// compile bpf object
-fn compile_bpf_object(args: &CompileOptions, source_path: &str, output_path: &str) -> Result<()> {
-    let bpf_sys_include = get_bpf_sys_include(args)?;
-    let target_arch = get_target_arch(args)?;
+fn compile_bpf_object(args: &Options, source_path: &str, output_path: &str) -> Result<()> {
+    let bpf_sys_include = get_bpf_sys_include(&args.compile_opts)?;
+    let target_arch = get_target_arch(&args.compile_opts)?;
 
     let command = format!(
         "{} -g -O2 -target bpf -D__TARGET_ARCH_{} {} {} {} {} -c {} -o {}",
-        args.clang_bin,
+        args.compile_opts.parameters.clang_bin,
         target_arch,
         bpf_sys_include,
         get_eunomia_include(args)?,
-        args.additional_cflags,
+        args.compile_opts.parameters.additional_cflags,
         get_base_dir_include(source_path)?,
         source_path,
         output_path
@@ -39,10 +39,13 @@ fn compile_bpf_object(args: &CompileOptions, source_path: &str, output_path: &st
         println!("$ {}\n {}", command, error);
         return Err(anyhow::anyhow!("failed to compile bpf object"));
     }
-    if args.verbose {
+    if args.compile_opts.verbose {
         println!("$ {}\n{}", command, output);
     }
-    let command = format!("{} -g {}", args.llvm_strip_bin, output_path);
+    let command = format!(
+        "{} -g {}",
+        args.compile_opts.parameters.llvm_strip_bin, output_path
+    );
     let (code, _output, error) = run_script::run_script!(command).unwrap();
     if code != 0 {
         println!("$ {}\n {}", command, error);
@@ -52,23 +55,23 @@ fn compile_bpf_object(args: &CompileOptions, source_path: &str, output_path: &st
 }
 
 /// get the skel as json object
-fn get_bpf_skel_json(object_path: &String, args: &CompileOptions) -> Result<String> {
-    let bpftool_bin = get_bpftool_path()?;
+fn get_bpf_skel_json(object_path: &String, args: &Options) -> Result<String> {
+    let bpftool_bin = get_bpftool_path(&args.tmpdir)?;
     let command = format!("{} gen skeleton {} -j", bpftool_bin, object_path);
     let (code, output, error) = run_script::run_script!(command).unwrap();
     if code != 0 {
         println!("$ {}\n {}", command, error);
         return Err(anyhow::anyhow!("failed to get bpf skel json"));
     }
-    if args.verbose {
+    if args.compile_opts.verbose {
         println!("$ {}\n{}", command, output);
     }
     Ok(output)
 }
 
 /// get the export typs as json object
-fn get_export_types_json(args: &CompileOptions, output_bpf_object_path: &String) -> Result<String> {
-    let bpftool_bin = get_bpftool_path()?;
+fn get_export_types_json(args: &Options, output_bpf_object_path: &String) -> Result<String> {
+    let bpftool_bin = get_bpftool_path(&args.tmpdir)?;
     let command = format!(
         "{} btf dump file {} format c -j",
         bpftool_bin, output_bpf_object_path
@@ -79,7 +82,7 @@ fn get_export_types_json(args: &CompileOptions, output_bpf_object_path: &String)
         return Err(anyhow::anyhow!("failed to get export types json"));
     }
     // fiter the output to get the export types json
-    let export_structs = find_all_export_structs(args)?;
+    let export_structs = find_all_export_structs(&args.compile_opts)?;
     let export_types_json: Value = parse_json_output(&output).unwrap();
     let export_types_json = export_types_json["structs"]
         .as_array()
@@ -91,14 +94,14 @@ fn get_export_types_json(args: &CompileOptions, output_bpf_object_path: &String)
         })
         .map(|x| x.to_owned())
         .collect::<Vec<Value>>();
-    if args.verbose {
+    if args.compile_opts.verbose {
         println!("$ {}\n{}", command, output);
     }
     Ok(serde_json::to_string(&export_types_json).unwrap())
 }
 
 /// do actual work for compiling
-fn do_compile(args: &CompileOptions, temp_source_file: &str) -> Result<()> {
+fn do_compile(args: &Options, temp_source_file: &str) -> Result<()> {
     let output_bpf_object_path = get_output_object_path(args);
     let output_json_path = get_output_config_path(args);
     let mut meta_json = json!({});
@@ -108,22 +111,22 @@ fn do_compile(args: &CompileOptions, temp_source_file: &str) -> Result<()> {
     compile_bpf_object(args, temp_source_file, &output_bpf_object_path)?;
     let bpf_skel_json = get_bpf_skel_json(&output_bpf_object_path, args)?;
     let bpf_skel = parse_json_output(&bpf_skel_json)?;
-    let bpf_skel_with_doc = match parse_source_documents(args, &args.source_path, bpf_skel.clone())
-    {
-        Ok(v) => v,
-        Err(e) => {
-            if e.to_string()
-                != "Failed to create Clang instance: an instance of `Clang` already exists"
-            {
-                panic!("failed to parse source documents: {}", e);
-            };
-            bpf_skel
-        }
-    };
+    let bpf_skel_with_doc =
+        match parse_source_documents(args, &args.compile_opts.source_path, bpf_skel.clone()) {
+            Ok(v) => v,
+            Err(e) => {
+                if e.to_string()
+                    != "Failed to create Clang instance: an instance of `Clang` already exists"
+                {
+                    panic!("failed to parse source documents: {}", e);
+                };
+                bpf_skel
+            }
+        };
     meta_json["bpf_skel"] = bpf_skel_with_doc;
 
     // compile export types
-    if !args.export_event_header.is_empty() {
+    if !args.compile_opts.export_event_header.is_empty() {
         println!("Generating export types...");
         let export_types_json = get_export_types_json(args, &output_bpf_object_path)?;
         let export_types_json: Value = parse_json_output(&export_types_json)?;
@@ -133,7 +136,7 @@ fn do_compile(args: &CompileOptions, temp_source_file: &str) -> Result<()> {
     // add version
     meta_json["eunomia_version"] = json!(include_str!("../../../VERSION"));
 
-    let meta_config_str = if args.yaml {
+    let meta_config_str = if args.compile_opts.yaml {
         serde_yaml::to_string(&meta_json)?
     } else {
         serde_json::to_string(&meta_json)?
@@ -143,33 +146,33 @@ fn do_compile(args: &CompileOptions, temp_source_file: &str) -> Result<()> {
 }
 
 /// compile JSON file
-pub fn compile_bpf(args: &CompileOptions) -> Result<()> {
+pub fn compile_bpf(args: &Options) -> Result<()> {
     // backup old files
-    let source_file_content = fs::read_to_string(&args.source_path)?;
-    let mut temp_source_file = args.source_path.clone();
+    let source_file_content = fs::read_to_string(&args.compile_opts.source_path)?;
+    let mut temp_source_file = args.compile_opts.source_path.clone();
 
-    if !args.export_event_header.is_empty() {
+    if !args.compile_opts.export_event_header.is_empty() {
         temp_source_file = get_source_file_temp_path(args);
         // create temp source file
         fs::write(&temp_source_file, source_file_content)?;
-        add_unused_ptr_for_structs(args, &temp_source_file)?;
+        add_unused_ptr_for_structs(&args.compile_opts, &temp_source_file)?;
     }
     let res = do_compile(args, &temp_source_file);
-    if !args.export_event_header.is_empty() {
+    if !args.compile_opts.export_event_header.is_empty() {
         fs::remove_file(temp_source_file)?;
     }
     res
 }
 
 /// pack the object file into a package.json
-pub fn pack_object_in_config(args: &CompileOptions) -> Result<()> {
+pub fn pack_object_in_config(args: &Options) -> Result<()> {
     let output_bpf_object_path = get_output_object_path(args);
     let bpf_object = fs::read(output_bpf_object_path)?;
 
     let mut e = ZlibEncoder::new(Vec::new(), Compression::default());
     e.write_all(&bpf_object)?;
     let compressed_bytes = e.finish().unwrap();
-    let encode_bpf_object = base64::encode(&compressed_bytes);
+    let encode_bpf_object = base64::encode(compressed_bytes);
     let output_json_path = get_output_config_path(args);
     let meta_json_str = fs::read_to_string(&output_json_path).unwrap();
     let meta_json: Value = if let Ok(json) = parse_json_output(&meta_json_str) {
@@ -182,7 +185,7 @@ pub fn pack_object_in_config(args: &CompileOptions) -> Result<()> {
         "bpf_object_size": bpf_object.len(),
         "meta": meta_json,
     });
-    if args.yaml {
+    if args.compile_opts.yaml {
         let output_package_config_path = Path::new(&output_json_path)
             .parent()
             .unwrap()
@@ -211,18 +214,25 @@ pub fn pack_object_in_config(args: &CompileOptions) -> Result<()> {
 #[cfg(test)]
 mod test {
     const TEMP_EUNOMIA_DIR: &str = "/tmp/eunomia";
+    use eunomia_rs::TempDir;
     use std::path;
 
     use super::*;
 
     #[test]
     fn test_get_attr() {
-        let args = CompileOptions {
-            ..Default::default()
+        let tmp_workspace = TempDir::new().unwrap();
+        init_eunomia_workspace(&tmp_workspace).unwrap();
+        let args = Options {
+            tmpdir: tmp_workspace,
+            compile_opts: CompileOptions {
+                ..Default::default()
+            },
         };
-        let sys_include = get_bpf_sys_include(&args).unwrap();
+
+        let sys_include = get_bpf_sys_include(&args.compile_opts).unwrap();
         println!("{}", sys_include);
-        let target_arch = get_target_arch(&args).unwrap();
+        let target_arch = get_target_arch(&args.compile_opts).unwrap();
         println!("{}", target_arch);
         let eunomia_include = get_eunomia_include(&args).unwrap();
         println!("{}", eunomia_include);
@@ -245,16 +255,25 @@ mod test {
         fs::write(&source_path, test_bpf).unwrap();
         let event_path = tmp_dir.join("event.h");
         fs::write(&event_path, test_event).unwrap();
-        let mut args = CompileOptions {
-            source_path: source_path.to_str().unwrap().to_string(),
-            clang_bin: "clang".to_string(),
-            llvm_strip_bin: "llvm-strip".to_string(),
-            output_path: "/tmp/eunomia/test".to_string(),
-            export_event_header: event_path.to_str().unwrap().to_string(),
-            ..Default::default()
+        let tmp_workspace = TempDir::new().unwrap();
+        init_eunomia_workspace(&tmp_workspace).unwrap();
+
+        let mut args = Options {
+            tmpdir: tmp_workspace,
+            compile_opts: CompileOptions {
+                source_path: source_path.to_str().unwrap().to_string(),
+                output_path: "/tmp/eunomia/test".to_string(),
+                export_event_header: event_path.to_str().unwrap().to_string(),
+                parameters: CompileParams {
+                    clang_bin: "clang".to_string(),
+                    llvm_strip_bin: "llvm-strip".to_string(),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
         };
         compile_bpf(&args).unwrap();
-        args.yaml = true;
+        args.compile_opts.yaml = true;
         compile_bpf(&args).unwrap();
         let _ = fs::remove_dir_all(tmp_dir);
     }
@@ -275,13 +294,22 @@ mod test {
         fs::write(&source_path, test_bpf).unwrap();
         let event_path = tmp_dir.join("event.h");
         fs::write(&event_path, test_event).unwrap();
-        let args = CompileOptions {
-            source_path: source_path.to_str().unwrap().to_string(),
-            clang_bin: "clang".to_string(),
-            llvm_strip_bin: "llvm-strip".to_string(),
-            output_path: "/tmp/eunomia/export_multi_struct_test".to_string(),
-            export_event_header: event_path.to_str().unwrap().to_string(),
-            ..Default::default()
+        let tmp_workspace = TempDir::new().unwrap();
+        init_eunomia_workspace(&tmp_workspace).unwrap();
+
+        let args = Options {
+            tmpdir: tmp_workspace,
+            compile_opts: CompileOptions {
+                source_path: source_path.to_str().unwrap().to_string(),
+                output_path: "/tmp/eunomia/export_multi_struct_test".to_string(),
+                export_event_header: event_path.to_str().unwrap().to_string(),
+                parameters: CompileParams {
+                    clang_bin: "clang".to_string(),
+                    llvm_strip_bin: "llvm-strip".to_string(),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
         };
         compile_bpf(&args).unwrap();
         pack_object_in_config(&args).unwrap();

--- a/compiler/cmd/src/export_types.rs
+++ b/compiler/cmd/src/export_types.rs
@@ -55,7 +55,7 @@ mod test {
     use super::*;
     #[test]
     fn test_match_struct() {
-        let tmp_file = "tmp_test_event.h";
+        let tmp_file = "/tmp/tmp_test_event.h";
         let arg = CompileOptions {
             export_event_header: tmp_file.to_string(),
             ..Default::default()

--- a/eunomia-sdks/eunomia-rs/Cargo.toml
+++ b/eunomia-sdks/eunomia-rs/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT"
 [dependencies]
 anyhow = "1.0"
 home = "0.5.4"
+fastrand = "1.6.0"
 
 [lib]
 crate-type = ["lib", "staticlib"]

--- a/eunomia-sdks/eunomia-rs/src/lib.rs
+++ b/eunomia-sdks/eunomia-rs/src/lib.rs
@@ -1,11 +1,13 @@
-use std::path;
-
 use anyhow::Result;
+use std::ffi::OsString;
+use std::fs::create_dir_all;
+use std::iter::repeat_with;
+use std::path::{Path, PathBuf};
+use std::{env, fs, io, mem};
 
 static EUNOMIA_HOME_ENV: &str = "EUNOMIA_HOME";
-static FHS_EUNOMIA_HOME_ENTRY: &str = "/usr/share/eunomia";
 
-/// Get home directory from env
+/// Get eunomia home directory
 pub fn get_eunomia_home() -> Result<String> {
     let eunomia_home = std::env::var(EUNOMIA_HOME_ENV);
     match eunomia_home {
@@ -13,16 +15,95 @@ pub fn get_eunomia_home() -> Result<String> {
         Err(_) => match home::home_dir() {
             Some(home) => {
                 let home = home.join(".eunomia");
+                if !home.exists() {
+                    create_dir_all(&home).unwrap()
+                }
                 Ok(home.to_str().unwrap().to_string())
             }
-            None => {
-                if path::Path::new(FHS_EUNOMIA_HOME_ENTRY).exists() {
-                    Ok(FHS_EUNOMIA_HOME_ENTRY.to_string())
-                } else {
-                    Err(anyhow::anyhow!("HOME is not found"))
-                }
-            }
+            None => Err(anyhow::anyhow!(
+                "home dir not found. Please set EUNOMIA_HOME env."
+            )),
         },
+    }
+}
+
+pub struct TempDir {
+    path: Box<Path>,
+}
+
+pub fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<()> {
+    fs::create_dir_all(&dst)?;
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let ty = entry.file_type()?;
+        if ty.is_dir() {
+            copy_dir_all(entry.path(), dst.as_ref().join(entry.file_name()))?;
+        } else {
+            fs::copy(entry.path(), dst.as_ref().join(entry.file_name()))?;
+        }
+    }
+    Ok(())
+}
+
+fn create_tmp_dir(path: PathBuf) -> io::Result<TempDir> {
+    match fs::create_dir_all(&path) {
+        // tmp workspace exist, return as well
+        Err(e) if e.kind() == io::ErrorKind::AlreadyExists => Ok(TempDir {
+            path: path.into_boxed_path(),
+        }),
+        Ok(_) => Ok(TempDir {
+            path: path.into_boxed_path(),
+        }),
+        _ => Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "Cannot create temporary workspace",
+        )),
+    }
+}
+
+impl TempDir {
+    /// Create a temporary directory with random suffix
+    pub fn new() -> io::Result<TempDir> {
+        let tmp_dir_from_env = &env::temp_dir();
+
+        let mut buf = OsString::with_capacity(8 + 6);
+        let mut char_buf = [0u8; 4];
+        buf.push("eunomia.");
+
+        for c in repeat_with(fastrand::alphanumeric).take(6) {
+            buf.push(c.encode_utf8(&mut char_buf));
+        }
+
+        let path = tmp_dir_from_env.join(buf);
+
+        create_tmp_dir(path)
+    }
+
+    /// Return path of temporary directory
+    pub fn path(&self) -> &Path {
+        self.path.as_ref()
+    }
+
+    pub fn close(mut self) -> io::Result<()> {
+        let result = fs::remove_dir_all(self.path());
+
+        self.path = PathBuf::default().into_boxed_path();
+
+        mem::forget(self);
+
+        result
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(self.path());
+    }
+}
+
+impl Default for TempDir {
+    fn default() -> Self {
+        Self::new().unwrap()
     }
 }
 

--- a/examples/tests/Makefile
+++ b/examples/tests/Makefile
@@ -2,7 +2,7 @@ TEST_EXAMPLE_DIR ?= ../bpftools/
 TEST_TIME ?= 2
 ECLI_DIR ?= ../../ecli/
 ECC_DIR ?= ../../compiler/
-ECC_BIN ?= ~/.eunomia/bin/ecc
+ECC_BIN ?= ../../compiler/workspace/bin/ecc
 
 # TODO: maybe use the compile docker to test?
 


### PR DESCRIPTION
## Description
+ Removes `eunomia_home` in ecc, loading dependencies
into a temporary directory at runtime, and automatically deleted.

+ Add customize workspace option.

+ Fix 2 _GitHub security warnings_ scanned by clippy.
https://github.com/eunomia-bpf/eunomia-bpf/security/code-scanning/22 and https://github.com/eunomia-bpf/eunomia-bpf/security/code-scanning/23  

__dependencies changes:__
+ introduce fastrand 1.6.0

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- [x] Tested compilation of ecc, bpftool, ecli on openEuler 22.09 and NixOS
- [x] Tested basic functionality of all binary files with running example/bpftool/minimal
- [x] Passed `make test`  

**Test Configuration**:  

openEuler 22.09
x86_64 & aarch64 VM
5.10.0-106.18.0.68.oe2209.x86_64
clang version 12.0.1
cargo 1.60.0


NixOS 23.05.20230119.d7705c0 (Stoat)
x86_64
6.1.6
clang version 14.0.6
cargo 1.68.0-nightly (985d561f0 2023-01-20)


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

