### PR TITLE
Introduce header only flag in compiler

### DIFF
--- a/compiler/cmd/src/compile_bpf.rs
+++ b/compiler/cmd/src/compile_bpf.rs
@@ -161,11 +161,14 @@ pub fn compile_bpf(args: &Options) -> Result<()> {
     if !args.compile_opts.export_event_header.is_empty() {
         fs::remove_file(temp_source_file)?;
     }
+    if !args.compile_opts.parameters.subskeleton {
+        pack_object_in_config(&args).unwrap();
+    }
     res
 }
 
 /// pack the object file into a package.json
-pub fn pack_object_in_config(args: &Options) -> Result<()> {
+fn pack_object_in_config(args: &Options) -> Result<()> {
     let output_bpf_object_path = get_output_object_path(args);
     let bpf_object = fs::read(output_bpf_object_path)?;
 

--- a/compiler/cmd/src/compile_bpf.rs
+++ b/compiler/cmd/src/compile_bpf.rs
@@ -24,7 +24,7 @@ fn compile_bpf_object(args: &Options, source_path: &str, output_path: &str) -> R
     let target_arch = get_target_arch(&args.compile_opts)?;
 
     let command = format!(
-        "{} -g -O2 -target bpf -D__TARGET_ARCH_{} {} {} {} {} -c {} -o {}",
+        "{} -g -O2 -target bpf -Wno-unknown-attributes -D__TARGET_ARCH_{} {} {} {} {} -c {} -o {}",
         args.compile_opts.parameters.clang_bin,
         target_arch,
         bpf_sys_include,

--- a/compiler/cmd/src/config.rs
+++ b/compiler/cmd/src/config.rs
@@ -1,6 +1,5 @@
 use std::{fs, path};
 
-use crate::compile_bpf::pack_object_in_config;
 use anyhow::Result;
 use clap::Parser;
 use eunomia_rs::{copy_dir_all, TempDir};
@@ -47,14 +46,6 @@ impl EunomiaWorkspace {
         Ok(EunomiaWorkspace {
             options: Options::init(opts, tmp_workspace)?,
         })
-    }
-}
-
-impl Drop for EunomiaWorkspace {
-    fn drop(&mut self) {
-        if !self.options.compile_opts.parameters.subskeleton {
-            pack_object_in_config(&self.options).unwrap();
-        }
     }
 }
 
@@ -349,5 +340,19 @@ mod test {
         // check if workspace and file successfully created
         let bpftool_path = tmp_workspace.path().join("bin/bpftool");
         assert!(bpftool_path.exists());
+        let _ = fs::create_dir("/tmp/test_workspace");
+        // test specifiy workspace
+        let _w1 = EunomiaWorkspace::init(CompileOptions::parse_from(&[
+            "ecc",
+            "../test/client.bpf.c",
+            "-w",
+            "/tmp/test_workspace",
+        ]))
+        .unwrap();
+
+        // test default workspace
+        let _w2 =
+            EunomiaWorkspace::init(CompileOptions::parse_from(&["ecc", "../test/client.bpf.c"]))
+                .unwrap();
     }
 }

--- a/compiler/cmd/src/config.rs
+++ b/compiler/cmd/src/config.rs
@@ -17,7 +17,7 @@ impl Options {
     fn check_compile_opts(opts: &mut CompileOptions) -> Result<()> {
         if opts.header_only {
             // treat header as a source file
-            opts.export_event_header = opts.source_path.clone();
+            opts.export_event_header.clone_from(&opts.source_path);
         }
         Ok(())
     }

--- a/compiler/cmd/src/config.rs
+++ b/compiler/cmd/src/config.rs
@@ -340,7 +340,7 @@ mod test {
         // check if workspace and file successfully created
         let bpftool_path = tmp_workspace.path().join("bin/bpftool");
         assert!(bpftool_path.exists());
-        let _ = fs::create_dir("/tmp/test_workspace");
+        let _ = fs::create_dir_all("/tmp/test_workspace");
         // test specifiy workspace
         let _w1 = EunomiaWorkspace::init(CompileOptions::parse_from(&[
             "ecc",

--- a/compiler/cmd/src/document_parser.rs
+++ b/compiler/cmd/src/document_parser.rs
@@ -18,7 +18,13 @@ fn parse_source_files<'a>(
     let target_arch = String::from("-D__TARGET_ARCH_") + &target_arch;
     let eunomia_include = get_eunomia_include(args)?;
     let base_dir_include = get_base_dir_include(source_path)?;
-    let mut compile_args = vec!["-g", "-O2", "-target bpf", &target_arch];
+    let mut compile_args = vec![
+        "-g",
+        "-O2",
+        "-target bpf",
+        "-Wno-unknown-attributes ",
+        &target_arch,
+    ];
     compile_args.append(&mut bpf_sys_include.split(' ').collect::<Vec<&str>>());
     compile_args.append(&mut eunomia_include.split(' ').collect::<Vec<&str>>());
     compile_args.push(&base_dir_include);

--- a/compiler/cmd/src/main.rs
+++ b/compiler/cmd/src/main.rs
@@ -6,34 +6,13 @@ mod export_types;
 use anyhow::Result;
 use clap::Parser;
 use compile_bpf::*;
-use config::{init_eunomia_workspace, CompileOptions, Options};
-use eunomia_rs::{copy_dir_all, TempDir};
-use std::path::Path;
+use config::{CompileOptions, EunomiaWorkspace};
 
 fn main() -> Result<()> {
     let args = CompileOptions::parse();
+    let workspace = EunomiaWorkspace::init(args)?;
 
-    let tmp_workspace = TempDir::new().unwrap();
-
-    let opts = Options {
-        compile_opts: args.clone(),
-        tmpdir: tmp_workspace,
-    };
-
-    if let Some(ref p) = args.parameters.workspace_path {
-        let src = Path::new(p);
-        copy_dir_all(src, opts.tmpdir.path()).unwrap();
-    } else {
-        init_eunomia_workspace(&opts.tmpdir)?
-    }
-
-    compile_bpf(&opts)?;
-
-    if !args.parameters.subskeleton {
-        pack_object_in_config(&opts)?;
-    }
-
-    opts.tmpdir.close()?;
+    compile_bpf(&workspace.options)?;
 
     Ok(())
 }


### PR DESCRIPTION
## Description

see https://github.com/eunomia-bpf/c-struct-bindgen

A new flag is used for generate bindings:

```
ecc examples/test-event.h --header-only
struct-bindgen examples/source.bpf.o
```

add workspace struct to handle drop

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [X] Locally

**Test Configuration**:

- Ubuntu 22.04

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- X ] I have checked my code and corrected any misspellings
