### PR TITLE
draft: replace bpf_main function in wasm module with main

### DIFF
--- a/wasm-runtime/scripts/build.sh
+++ b/wasm-runtime/scripts/build.sh
@@ -23,7 +23,7 @@ echo "${INCLUDE_DIR}"
         -I "${INCLUDE_DIR}" \
         -Wl,--allow-undefined-file=${WAMR_DIR}/wamr-sdk/app/libc-builtin-sysroot/share/defined-symbols.txt \
         -Wl,--export=all \
-        -Wl,--export=bpf_main \
+        -Wl,--export=main \
         -Wl,--export=process_event \
         -Wl,--strip-all,--no-entry \
         -Wl,--allow-undefined \
@@ -52,7 +52,7 @@ OUT_FILE=${i%.*}.wasm
         -I "${INCLUDE_DIR}" \
         -Wl,--allow-undefined-file=${WAMR_DIR}/wamr-sdk/app/libc-builtin-sysroot/share/defined-symbols.txt \
         -Wl,--export=all \
-        -Wl,--export=bpf_main \
+        -Wl,--export=main \
         -Wl,--export=process_event \
         -Wl,--strip-all,--no-entry \
         -Wl,--allow-undefined \

--- a/wasm-runtime/src/ewasm.cpp
+++ b/wasm-runtime/src/ewasm.cpp
@@ -67,7 +67,8 @@ ewasm_program::start(std::vector<char> &buffer_vector, std::string &json_env)
         printf("Init wasm functions failed.\n");
         return -1;
     }
-    return call_wasm_init(json_env);
+    wasm_application_execute_main(module_inst, 0, NULL);
+    // return call_wasm_init(json_env);
 }
 
 int

--- a/wasm-runtime/src/ewasm.cpp
+++ b/wasm-runtime/src/ewasm.cpp
@@ -83,7 +83,7 @@ ewasm_program::init_wasm_functions()
         return -1;
     }
     if (!(wasm_init_func =
-              wasm_runtime_lookup_function(module_inst, "bpf_main", NULL))) {
+              wasm_runtime_lookup_function(module_inst, "_start", NULL))) {
         printf("The wasm function main wasm function is not found. Use default "
                "main function instead.\n");
         return -1;

--- a/wasm-runtime/test/wasm-apps/binding.c
+++ b/wasm-runtime/test/wasm-apps/binding.c
@@ -9,7 +9,7 @@
 /// @return 0 on success, -1 on failure, the eBPF program will be terminated in
 /// failure case
 int
-bpf_main(char *env_json, int str_len)
+main(int argc, char **args)
 {
     int res = create_bpf("hhhh", 3);
     printf("create_bpf %d\n", res);

--- a/wasm-runtime/test/wasm-apps/binding.c
+++ b/wasm-runtime/test/wasm-apps/binding.c
@@ -11,7 +11,6 @@
 int
 bpf_main(char *env_json, int str_len)
 {
-    printf("calling into init: %s %d", env_json, str_len);
     int res = create_bpf("hhhh", 3);
     printf("create_bpf %d\n", res);
     res = run_bpf(0);

--- a/wasm-runtime/test/wasm-apps/cpp-opensnoop.cpp
+++ b/wasm-runtime/test/wasm-apps/cpp-opensnoop.cpp
@@ -13,8 +13,12 @@ extern "C" {
 /// @return 0 on success, -1 on failure, the eBPF program will be terminated in
 /// failure case
 int
-bpf_main(char *env_json, int str_len)
+main(int argc, char **args)
 {
+    if (argc != 3)
+        printf("error: the number of parameters passed is not equal to 2.");
+    int str_len = atoi(args[2]);
+    char *env_json = args[1];
     int res = create_bpf(program_data, strlen(program_data));
     if (res < 0) {
         printf("create_bpf failed %d", res);

--- a/wasm-runtime/test/wasm-apps/cpp-opensnoop.cpp
+++ b/wasm-runtime/test/wasm-apps/cpp-opensnoop.cpp
@@ -15,10 +15,6 @@ extern "C" {
 int
 main(int argc, char **args)
 {
-    if (argc != 3)
-        printf("error: the number of parameters passed is not equal to 2.");
-    int str_len = atoi(args[2]);
-    char *env_json = args[1];
     int res = create_bpf(program_data, strlen(program_data));
     if (res < 0) {
         printf("create_bpf failed %d", res);

--- a/wasm-runtime/test/wasm-apps/init_only.c
+++ b/wasm-runtime/test/wasm-apps/init_only.c
@@ -12,10 +12,6 @@
 int
 main(int argc, char **args)
 {
-    if (argc != 3)
-        printf("error: the number of parameters passed is not equal to 2.");
-    int str_len = atoi(args[2]);
-    char *env_json = args[1];
     int res = create_bpf(program_data, strlen(program_data));
     if (res < 0) {
         printf("create_bpf failed %d", res);

--- a/wasm-runtime/test/wasm-apps/init_only.c
+++ b/wasm-runtime/test/wasm-apps/init_only.c
@@ -10,8 +10,12 @@
 /// @return 0 on success, -1 on failure, the eBPF program will be terminated in
 /// failure case
 int
-bpf_main(char *env_json, int str_len)
+main(int argc, char **args)
 {
+    if (argc != 3)
+        printf("error: the number of parameters passed is not equal to 2.");
+    int str_len = atoi(args[2]);
+    char *env_json = args[1];
     int res = create_bpf(program_data, strlen(program_data));
     if (res < 0) {
         printf("create_bpf failed %d", res);

--- a/wasm-runtime/test/wasm-apps/opensnoop.c
+++ b/wasm-runtime/test/wasm-apps/opensnoop.c
@@ -13,10 +13,6 @@
 int
 main(int argc, char **args)
 {
-    if (argc != 3)
-        printf("error: the number of parameters passed is not equal to 2.");
-    int str_len = atoi(args[2]);
-    char *env_json = args[1];
     int res = create_bpf(program_data, strlen(program_data));
     if (res < 0) {
         printf("create_bpf failed %d", res);

--- a/wasm-runtime/test/wasm-apps/opensnoop.c
+++ b/wasm-runtime/test/wasm-apps/opensnoop.c
@@ -11,8 +11,12 @@
 /// @return 0 on success, -1 on failure, the eBPF program will be terminated in
 /// failure case
 int
-bpf_main(char *env_json, int str_len)
+main(int argc, char **args)
 {
+    if (argc != 3)
+        printf("error: the number of parameters passed is not equal to 2.");
+    int str_len = atoi(args[2]);
+    char *env_json = args[1];
     int res = create_bpf(program_data, strlen(program_data));
     if (res < 0) {
         printf("create_bpf failed %d", res);

--- a/wasm-runtime/test/wasm-apps/process_only.c
+++ b/wasm-runtime/test/wasm-apps/process_only.c
@@ -9,10 +9,6 @@
 int
 main(int argc, char **args)
 {
-    if (argc != 3)
-        printf("error: the number of parameters passed is not equal to 2.");
-    int str_len = atoi(args[2]);
-    char *env_json = args[1];
     return start_bpf_program(program_data);
 }
 

--- a/wasm-runtime/test/wasm-apps/process_only.c
+++ b/wasm-runtime/test/wasm-apps/process_only.c
@@ -7,8 +7,12 @@
 #include "opensnoop.h"
 
 int
-bpf_main(char *env_json, int str_len)
+main(int argc, char **args)
 {
+    if (argc != 3)
+        printf("error: the number of parameters passed is not equal to 2.");
+    int str_len = atoi(args[2]);
+    char *env_json = args[1];
     return start_bpf_program(program_data);
 }
 


### PR DESCRIPTION
## Description

It's related to [issue#116](https://github.com/eunomia-bpf/eunomia-bpf/issues/116)

We need replace the host api in `wasm-runtime` that execute `bpf_main` function with `wasm_application_execute_main`.