### PR TITLE
Add compile docker for aarch64

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ With eunnomia-bpf, you can:
   or use the docker image for compile:
 
     ```bash
-    docker run -it -v `pwd`/:/src/ yunwei37/ebpm:latest # compile with docker. `pwd` should contains *.bpf.c files and *.h files.
+    docker run -it -v `pwd`/:/src/ ghcr.io/eunomia-bpf/ecc-`uname -m`:latest # compile with docker. `pwd` should contains *.bpf.c files and *.h files.
     ```
 
 - build the compiler, runtime library and tools:
@@ -195,7 +195,7 @@ Just Write libbpf eBPF kernel code only, auto config the userspace part!
     Compiling bpf object...
     Generating export types...
     Packing ebpf object and config into package.json...
-    $ docker run -it -v `pwd`/:/src/ yunwei37/ebpm:latest # build with docker
+    $ docker run -it -v `pwd`/:/src/ ghcr.io/eunomia-bpf/ecc-`uname -m`:latest # build with docker
     Packing ebpf object and config into package.json...
     ```
 
@@ -302,8 +302,8 @@ sudo ./ecli run https://eunomia-bpf.github.io/eunomia-bpf/sigsnoop/app.wasm
 You can also generate a WASM program template for eBPF or build WASM module with `compiler` container:
 
 ```shell
-docker run -it -v `pwd`/:/src/ yunwei37/ebpm:latest gen-wasm-skel # generate WASM app template for eBPF
-docker run -it -v `pwd`/:/src/ yunwei37/ebpm:latest build-wasm    # Build WASM module
+docker run -it -v `pwd`/:/src/ ghcr.io/eunomia-bpf/ecc-`uname -m`:latest gen-wasm-skel # generate WASM app template for eBPF
+docker run -it -v `pwd`/:/src/ ghcr.io/eunomia-bpf/ecc-`uname -m`:latest build-wasm    # Build WASM module
 ```
 
 see [sigsnoop example](examples/bpftools/sigsnoop) for more detail.

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -105,11 +105,11 @@ build:
 
 .PHONY: docker
 docker: wasi-sdk-16.0-linux.tar.gz
-	docker build -t yunwei37/ebpm:latest .
+	sudo docker build -t ghcr.io/eunomia-bpf/ecc-$(shell uname -m):latest .
 
 .PHONY: docker-push
 docker-push:
-	docker push yunwei37/ebpm:latest
+	sudo docker push ghcr.io/eunomia-bpf/ecc-$(shell uname -m):latest
 
 .PHONY: install-deps
 install-deps:

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -106,10 +106,16 @@ build:
 .PHONY: docker
 docker: wasi-sdk-16.0-linux.tar.gz
 	sudo docker build -t ghcr.io/eunomia-bpf/ecc-$(shell uname -m):latest .
+ifeq ("$(shell uname -m)", "x86_64")
+	docker build -t yunwei37/ebpm:latest .
+endif
 
 .PHONY: docker-push
 docker-push:
 	sudo docker push ghcr.io/eunomia-bpf/ecc-$(shell uname -m):latest
+ifeq ("$(shell uname -m)", "x86_64")
+	docker push yunwei37/ebpm:latest
+endif
 
 .PHONY: install-deps
 install-deps:

--- a/examples/README.md
+++ b/examples/README.md
@@ -64,13 +64,13 @@ Generate WASM skel:
 > - app.c: the WASM app. all library is header only.
 
 ```shell
-docker run -it -v `pwd`/:/src/ yunwei37/ebpm:latest gen-wasm-skel
+docker run -it -v `pwd`/:/src/ ghcr.io/eunomia-bpf/ecc-`uname -m`:latest gen-wasm-skel
 ```
 
 Build WASM module
 
 ```shell
-docker run -it -v `pwd`/:/src/ yunwei37/ebpm:latest build-wasm
+docker run -it -v `pwd`/:/src/ ghcr.io/eunomia-bpf/ecc-`uname -m`:latest build-wasm
 ```
 
 Run:

--- a/examples/bpftools/bashreadline/README.md
+++ b/examples/bpftools/bashreadline/README.md
@@ -23,7 +23,7 @@ This prints bash commands from all running bash shells on the system.
 - Compile:
 
   ```shell
-  docker run -it -v `pwd`/:/src/ yunwei37/ebpm:latest
+  docker run -it -v `pwd`/:/src/ ghcr.io/eunomia-bpf/ecc-`uname -m`:latest
   ```
 
   or

--- a/examples/bpftools/bootstrap/README.md
+++ b/examples/bpftools/bootstrap/README.md
@@ -63,7 +63,7 @@ TIME     PID     PPID    EXIT_CODE  DURATION_NS  COMM    FILENAME  EXIT_EVENT
 - Compile:
 
   ```shell
-  docker run -it -v `pwd`/:/src/ yunwei37/ebpm:latest
+  docker run -it -v `pwd`/:/src/ ghcr.io/eunomia-bpf/ecc-`uname -m`:latest
   ```
 
   or

--- a/examples/bpftools/fentry-link/README.md
+++ b/examples/bpftools/fentry-link/README.md
@@ -47,7 +47,7 @@ $ sudo cat /sys/kernel/debug/tracing/trace_pipe
 - Compile:
 
     ```console
-    docker run -it -v `pwd`/:/src/ yunwei37/ebpm:latest
+    docker run -it -v `pwd`/:/src/ ghcr.io/eunomia-bpf/ecc-`uname -m`:latest
     ```
 
     or

--- a/examples/bpftools/kprobe-link/README.md
+++ b/examples/bpftools/kprobe-link/README.md
@@ -37,7 +37,7 @@ $ sudo cat /sys/kernel/debug/tracing/trace_pipe
 Compile with docker:
 
 ```console
-docker run -it -v `pwd`/:/src/ yunwei37/ebpm:latest
+docker run -it -v `pwd`/:/src/ ghcr.io/eunomia-bpf/ecc-`uname -m`:latest
 ```
 
 or compile with `ecc`:

--- a/examples/bpftools/lsm-connect/README.md
+++ b/examples/bpftools/lsm-connect/README.md
@@ -12,7 +12,7 @@ summary: BPF LSM program (on socket_connect hook) that prevents any connection t
 ## run
 
 ```console
-docker run -it -v `pwd`/:/src/ yunwei37/ebpm:latest
+docker run -it -v `pwd`/:/src/ ghcr.io/eunomia-bpf/ecc-`uname -m`:latest
 ```
 
 or compile with `ecc`:

--- a/examples/bpftools/mdflush/README.md
+++ b/examples/bpftools/mdflush/README.md
@@ -21,7 +21,7 @@ origin from:
 Compile:
 
 ```shell
-docker run -it -v `pwd`/:/src/ yunwei37/ebpm:latest
+docker run -it -v `pwd`/:/src/ ghcr.io/eunomia-bpf/ecc-`uname -m`:latest
 ```
 
 or compile with `ecc`:

--- a/examples/bpftools/minimal/README.md
+++ b/examples/bpftools/minimal/README.md
@@ -39,7 +39,7 @@ new ideas or BPF features.
 Compile:
 
 ```console
-docker run -it -v `pwd`/:/src/ yunwei37/ebpm:latest
+docker run -it -v `pwd`/:/src/ ghcr.io/eunomia-bpf/ecc-`uname -m`:latest
 ```
 
 or compile with `ecc`:

--- a/examples/bpftools/opensnoop/README.md
+++ b/examples/bpftools/opensnoop/README.md
@@ -58,7 +58,7 @@ TIME     TS      PID     UID     RET     FLAGS   COMM    FNAME
 Compile with docker:
 
 ```shell
-docker run -it -v `pwd`/:/src/ yunwei37/ebpm:latest
+docker run -it -v `pwd`/:/src/ ghcr.io/eunomia-bpf/ecc-`uname -m`:latest
 ```
 
 or compile with `ecc`:

--- a/examples/bpftools/runqlat/README.md
+++ b/examples/bpftools/runqlat/README.md
@@ -23,7 +23,7 @@ how long tasks spent waiting their turn to run on-CPU.
 Compile:
 
 ```shell
-docker run -it -v `pwd`/:/src/ yunwei37/ebpm:latest
+docker run -it -v `pwd`/:/src/ ghcr.io/eunomia-bpf/ecc-`uname -m`:latest
 ```
 
 ```console

--- a/examples/bpftools/sigsnoop/README.md
+++ b/examples/bpftools/sigsnoop/README.md
@@ -22,7 +22,7 @@ This example include a eBPF program and a WASM module in user space.
 Compile:
 
 ```shell
-docker run -it -v `pwd`/:/src/ yunwei37/ebpm:latest
+docker run -it -v `pwd`/:/src/ ghcr.io/eunomia-bpf/ecc-`uname -m`:latest
 ```
 
 Or compile with `ecc`:
@@ -68,7 +68,7 @@ See https://github.com/eunomia-bpf/eunomia-bpf for more information.
 Generate WASM skel:
 
 ```shell
-docker run -it -v `pwd`/:/src/ yunwei37/ebpm:latest gen-wasm-skel
+docker run -it -v `pwd`/:/src/ ghcr.io/eunomia-bpf/ecc-`uname -m`:latest gen-wasm-skel
 ```
 
 > The skel is generated and commit, so you don't need to generate it again.
@@ -80,7 +80,7 @@ docker run -it -v `pwd`/:/src/ yunwei37/ebpm:latest gen-wasm-skel
 Build WASM module
 
 ```shell
-docker run -it -v `pwd`/:/src/ yunwei37/ebpm:latest build-wasm
+docker run -it -v `pwd`/:/src/ ghcr.io/eunomia-bpf/ecc-`uname -m`:latest build-wasm
 ```
 
 or install the [WASI SDK](https://github.com/WebAssembly/wasi-sdk/releases/download), and use the build script:

--- a/examples/bpftools/tc/README.md
+++ b/examples/bpftools/tc/README.md
@@ -38,7 +38,7 @@ $ sudo cat /sys/kernel/debug/tracing/trace_pipe
 Compile:
 
 ```console
-docker run -it -v `pwd`/:/src/ yunwei37/ebpm:latest
+docker run -it -v `pwd`/:/src/ ghcr.io/eunomia-bpf/ecc-`uname -m`:latest
 ```
 
 or compile with `ecc`:

--- a/examples/bpftools/tcpstates/README.md
+++ b/examples/bpftools/tcpstates/README.md
@@ -20,7 +20,7 @@ origin from:
 Compile:
 
 ```shell
-docker run -it -v `pwd`/:/src/ yunwei37/ebpm:latest
+docker run -it -v `pwd`/:/src/ ghcr.io/eunomia-bpf/ecc-`uname -m`:latest
 ```
 
 Or compile with `ecc`:


### PR DESCRIPTION
## Description

Add new docker for aarch64, for example:

```sh
sudo docker run -it -v `pwd`/:/src/ ghcr.io/eunomia-bpf/ecc-`uname -m`:latest
```

Fixes #124 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
