### PR TITLE
build ecc image

### DIFF
--- a/.github/workflows/ecc-image.yml
+++ b/.github/workflows/ecc-image.yml
@@ -1,0 +1,62 @@
+name: Build and public ecc docker image
+
+on:
+  push:
+    branches: "master"
+    paths:
+      - "VERSION"
+
+jobs:
+  # define job to build and publish docker image
+  build-and-push-ecc-image:
+    runs-on: ubuntu-latest
+    # run only when code is compiling and tests are passing
+    if: "!contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[ci skip]')"
+    # steps to perform in job
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: get submodule
+        run:  git submodule update --init --recursive
+
+      # setup Docker buld action
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Github Packages
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build ecc-x86_64 image and push to GitHub Container Registry
+        uses: docker/build-push-action@v2
+        with:
+          # relative path to the place where source code with Dockerfile is located
+          context: ./
+          file: ./compiler/dockerfile
+          platforms: linux/amd64
+          # Note: tags has to be all lower-case
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/ecc-x86_64:latest
+          push: true
+
+      - name: Build ecc-aarch64 image and push to GitHub Container Registry
+        uses: docker/build-push-action@v2
+        with:
+          # relative path to the place where source code with Dockerfile is located
+          context: ./
+          file: ./compiler/dockerfile
+          platforms: linux/arm64
+          # Note: tags has to be all lower-case
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/ecc-aarch64:latest
+          push: true
+
+
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/compiler/dockerfile
+++ b/compiler/dockerfile
@@ -1,19 +1,31 @@
-# build run env
 FROM ubuntu:22.04
 
-ENV TZ = Asia/Shanghai
-
 WORKDIR /usr/local/src
+COPY . /usr/local/src
 
-RUN apt-get update -y && apt-get install -y --no-install-recommends libelf1 libelf-dev zlib1g-dev clang make llvm libclang-13-dev && apt-get clean \
- && rm -rf /var/lib/apt/lists/*
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        libelf1 libelf-dev zlib1g-dev libclang-13-dev \
+        make wget cargo curl python2 clang llvm && \
+    apt-get install -y --no-install-recommends ca-certificates	&& \
+	update-ca-certificates	&& \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
-COPY ./. /usr/local/src
+RUN wget --progress=dot:giga --no-check-certificate \
+        https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-17/wasi-sdk-17.0-linux.tar.gz && \
+	tar -zxf wasi-sdk-17.0-linux.tar.gz && \
+    rm wasi-sdk-17.0-linux.tar.gz   && \
+	mkdir -p /opt/wasi-sdk/ && \
+    mv wasi-sdk-17.0/* /opt/wasi-sdk/
 
-RUN make install
-RUN tar -zxf wasi-sdk-16.0-linux.tar.gz && mkdir /opt/wasi-sdk/ && mv wasi-sdk-16.0/* /opt/wasi-sdk/
+RUN cp /usr/bin/python2 /usr/bin/python
 
-VOLUME /data/
+RUN make ecc    && \
+    make -C compiler install    && \
+    rm -rf compiler/cmd/target
+
+WORKDIR /usr/local/src/compiler
 
 ENTRYPOINT ["make"]
 CMD ["build"]


### PR DESCRIPTION
# Pull Request Template

## Description

The purpose of this PR is to enable automatic release and build of the ecc image by CI, corresponding to the related issue: https://github.com/eunomia-bpf/eunomia-bpf/issues/42.

This image can generate json-formatted BPF files normally, but it cannot generate wasm files normally, which is related to eunomia-bpf/wasm-runtime/scripts/Makefile.

By the way, the size of the image is approximately 1.96 GB, which is a bit large, but I'm unable to make it smaller.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
