### PR TITLE
fix-handler

### DIFF
--- a/ecli/ecli-rs/src/json_runner/json.rs
+++ b/ecli/ecli-rs/src/json_runner/json.rs
@@ -23,6 +23,7 @@ use super::eunomia_bpf::wait_and_poll_events_to_handler;
 unsafe extern "C" fn handler(
     _ctx: *mut ::std::os::raw::c_void,
     event: *const ::std::os::raw::c_char,
+    size: super::eunomia_bpf::size_t,
 ) {
     println!("{}", CStr::from_ptr(event).to_string_lossy().to_string());
 }


### PR DESCRIPTION
After executing the make command in `eunomia-bpf/ecli/ecli-rs`, the following error occurs:

```console
error[E0308]: mismatched types
  --> src/json_runner/json.rs:65:18
   |
65 |             Some(handler),
   |             ---- ^^^^^^^ incorrect number of function parameters
   |             |
   |             arguments to this enum variant are incorrect
   |
   = note: expected fn pointer `unsafe extern "C" fn(*mut c_void, *const i8, u64)`
                 found fn item `unsafe extern "C" fn(*mut c_void, *const i8) {handler}`
note: tuple variant defined here
  --> /rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library/core/src/option.rs:526:5

For more information about this error, try `rustc --explain E0308`.
warning: `ecli` (bin "ecli") generated 5 warnings
error: could not compile `ecli` due to previous error; 5 warnings emitted
make: *** [Makefile:6: build] Error 101
```

This seems to be caused by a mismatch between the argument list of the `handler` function and wait_and_poll_events_to_handler.

In the . /bpf-loader/include/eunomia/eunomia-bpf.h file, the function wait_and_poll_events_to_handler is declared as follows:

```cpp
wait_and_poll_events_to_handler(
    struct eunomia_bpf *prog, enum export_format_type type,
    void (*handler)(void *, const char *, size_t size), void *ctx);
```

So in this PR, I added a parameter to the handler definition: `size: super::eunomia_bpf::size_t`.