### PR TITLE
Fix minimal ecli build fail

### DIFF
--- a/.github/workflows/ecli.yaml
+++ b/.github/workflows/ecli.yaml
@@ -43,6 +43,9 @@ jobs:
     - name: make ecli
       run:  make ecli
 
+    - name: make minimal ecli
+      run:  make -C ecli/minimal
+
     # - name: run unit tests
     #   run: |
     #     cd ecli

--- a/ecli/minimal/CMakeLists.txt
+++ b/ecli/minimal/CMakeLists.txt
@@ -160,8 +160,8 @@ set(THIRD_PARTY_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../third_party)
 # Set the build/user include directories
 #
 set(EUNOMIA_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../bpf-loader)
-set(WASM_BPF_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../wasm-runtime)
-set(WAMR_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../wasm-runtime/third_party/wasm-micro-runtime)
+set(WASM_BPF_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../wasm-runtime/runtime/cpp)
+set(WAMR_ROOT_DIR ${WASM_BPF_DIR}/third_party/wasm-micro-runtime)
 include_directories(${EUNOMIA_DIR}/include)
 include_directories(${THIRD_PARTY_DIR}/includes/)
 include_directories(${WAMR_ROOT_DIR}/core/iwasm/include/)

--- a/ecli/minimal/src/eunomia_runner.cpp
+++ b/ecli/minimal/src/eunomia_runner.cpp
@@ -51,5 +51,7 @@ eunomia_program_runner::load_and_attach_eunomia_skel()
 int
 wasm_program_runner::load_and_attach_eunomia_skel()
 {
-    return wasm_main(current_config.program_data_buffer, 0, NULL);
+    return wasm_main(current_config.program_data_buffer.data(),
+                     (unsigned int)current_config.program_data_buffer.size(), 0,
+                     nullptr);
 }


### PR DESCRIPTION
This pr fixes minimal ecli build fail due to changes of wasm-bpf cpp runtime bpf-api.h.

Fix path in cmake script.

Related commit: 
- https://github.com/eunomia-bpf/wasm-bpf/commit/346d2f50b99330c03de3644592788d22141f66e1