### PR TITLE
fix docs web and README logo

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -25,4 +25,4 @@ jobs:
         if: ${{ github.event_name == 'push' }}
         with:
           branch: gh-pages
-          folder: ./documents/book
+          folder: ./documents/book/html

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![logo](docs/src/img/logo.png)
+![logo](documents/src/img/logo.png)
 
 # eunomia-bpf: simplify and enhance eBPF with CO-RE[^1] and WebAssembly[^2]
 


### PR DESCRIPTION
Adding linkcheck in #163 causes the mdbook directory to change (book -> book/html).
This PR fix this trouble.