### PR TITLE
ci: use checkout option recursive

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,8 +39,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
-    - name: get submodule
-      run:  git submodule update --init --recursive --remote
+      with:
+        submodules: 'recursive'
     - name: install deps
       run: |
           sudo make -C bpf-loader install-deps

--- a/.github/workflows/ecc-image.yml
+++ b/.github/workflows/ecc-image.yml
@@ -16,9 +16,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-
-      - name: get submodule
-        run:  git submodule update --init --recursive --remote
+        with:
+          submodules: 'recursive'
 
       # setup Docker buld action
       - name: Set up Docker Buildx

--- a/.github/workflows/ecc.yml
+++ b/.github/workflows/ecc.yml
@@ -95,6 +95,15 @@ jobs:
         path: ${{ github.workspace }}/${{ env.INSTALL_LOCATION }}
         key: ${{ runner.os }}-dependencies
 
+    - name: Cache rust
+      uses: Swatinem/rust-cache@v2
+      with:
+        workspaces: |
+          compiler/cmd
+          ecli
+          wasm-runtime/runtime/rust
+          eunomia-sdks/eunomia-rs
+
     - name: build ecc
       run:  cd compiler && make && make install
 

--- a/.github/workflows/ecc.yml
+++ b/.github/workflows/ecc.yml
@@ -39,6 +39,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        submodules: 'recursive'
 
     - name: Set latest release version
       if:   github.event_name == 'push' && github.ref == 'refs/heads/master'
@@ -71,9 +73,6 @@ jobs:
           const tag = tags.find(tag => tag.commit.sha === context.sha);
           
           return tag ? tag.name : increase_v(latest_release_tag)
-
-    - name: get submodule
-      run:  git submodule update --init --recursive --remote
 
     - name: install deps
       run: |

--- a/.github/workflows/ecli-image.yml
+++ b/.github/workflows/ecli-image.yml
@@ -16,9 +16,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-
-      - name: get submodule
-        run:  git submodule update --init --recursive --remote
+        with:
+          submodules: 'recursive'
 
       # setup Docker buld action
       - name: Set up Docker Buildx

--- a/.github/workflows/ecli.yaml
+++ b/.github/workflows/ecli.yaml
@@ -85,6 +85,15 @@ jobs:
         path: ${{ github.workspace }}/${{ env.INSTALL_LOCATION }}
         key: ${{ runner.os }}-dependencies
 
+    - name: cache rust
+      uses: Swatinem/rust-cache@v2
+      with:
+        workspaces: |
+          compiler/cmd
+          ecli
+          wasm-runtime/runtime/rust
+          eunomia-sdks/eunomia-rs
+
     - name: make ecli
       run:  make ecli
 

--- a/.github/workflows/ecli.yaml
+++ b/.github/workflows/ecli.yaml
@@ -37,6 +37,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        submodules: 'recursive'
 
     - name: Set latest release version
       if:   github.event_name == 'push' && github.ref == 'refs/heads/master'
@@ -70,9 +72,6 @@ jobs:
           const tag = tags.find(tag => tag.commit.sha === context.sha);
           
           return tag ? tag.name : increase_v(latest_release_tag)
-
-    - name: get submodule
-      run:  git submodule update --init --recursive --remote
 
     - name: install deps
       run: |

--- a/.github/workflows/eunomia-bpf.yml
+++ b/.github/workflows/eunomia-bpf.yml
@@ -17,9 +17,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-
-    - name: get submodule
-      run:  git submodule update --init --recursive --remote
+      with:
+        submodules: 'recursive'
 
     - name: install deps
       run: |

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -25,8 +25,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: get submodule
-        run:  git submodule update --init --recursive --remote
+        with:
+          submodules: 'recursive'
 
       - name: install deps
         run: |

--- a/.github/workflows/wasm-runtime.yml
+++ b/.github/workflows/wasm-runtime.yml
@@ -17,9 +17,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-
-    - name: get submodule
-      run:  git submodule update --init --recursive --remote
+      with:
+        submodules: 'recursive'
 
     - name: install deps
       run: |


### PR DESCRIPTION
Adding [Swatinem/rust-cache](https://github.com/Swatinem/rust-cache) to CI, saves about half the time.
Use the checkout option instead get submodule.