### PR TITLE
ci: fix ecc image build on aarch64

### DIFF
--- a/compiler/dockerfile
+++ b/compiler/dockerfile
@@ -21,6 +21,7 @@ RUN wget --progress=dot:giga --no-check-certificate \
 
 RUN cp /usr/bin/python2 /usr/bin/python
 
+ARG CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 RUN make ecc    && \
     make -C compiler install    && \
     rm -rf compiler/cmd/target


### PR DESCRIPTION
Fix ecc image build action.
See https://github.com/eunomia-bpf/eunomia-bpf/actions/runs/4453154030/jobs/7821436749