### PR TITLE
Ci test on aarch64

### DIFF
--- a/.github/workflows/ecc.yml
+++ b/.github/workflows/ecc.yml
@@ -77,7 +77,6 @@ jobs:
     - name: install deps
       run: |
           sudo make -C compiler install-deps
-          cargo install clippy-sarif sarif-fmt grcov
           rustup component add llvm-tools-preview
 
     - name: Install Rust toolchain
@@ -109,6 +108,23 @@ jobs:
 
     - name: test ecc
       run:  cd compiler && make test
+    
+    - uses: uraimo/run-on-arch-action@v2
+      name: test ecc on aarch64
+      id: runcmd
+      with:
+        arch: aarch64
+        distro: ubuntu_latest
+        dockerRunArgs: |
+          -v `pwd`/:/usr/eunomia-bpf/
+        githubToken: ${{ github.token }}
+        run: |
+          apt-get update
+          apt-get install git
+          cd /usr/eunomia-bpf/compiler
+          export CARGO_NET_GIT_FETCH_WITH_CLI=true
+          make install && make test
+
     - name: Upload analysis results to GitHub
       if: github.repository_owner == 'eunomia-bpf'
       uses: github/codeql-action/upload-sarif@v2

--- a/.github/workflows/ecli-image.yml
+++ b/.github/workflows/ecli-image.yml
@@ -46,18 +46,6 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build ecli-aarch64 image and push to GitHub Container Registry
-        uses: docker/build-push-action@v2
-        with:
-          # relative path to the place where source code with Dockerfile is located
-          context: ./
-          file: ./ecli/dockerfile
-          platforms: linux/arm64
-          # Note: tags has to be all lower-case
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/ecli-aarch64:latest
-          push: true
-
       - name: Build ecli-x86_64 image and push to GitHub Container Registry
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/eunomia-bpf.yml
+++ b/.github/workflows/eunomia-bpf.yml
@@ -39,6 +39,23 @@ jobs:
         cd bpf-loader/
         sudo make test
 
+    - uses: uraimo/run-on-arch-action@v2
+      name: run unit tests on aarch64
+      id: runcmd
+      with:
+        arch: aarch64
+        distro: ubuntu_latest
+        dockerRunArgs: |
+          -v `pwd`/:/usr/eunomia-bpf/
+        githubToken: ${{ github.token }}
+        run: |
+          apt-get update
+          apt-get install make cmake
+          cd /usr/eunomia-bpf/
+          make bpf-loader
+          make -C bpf-loader install-deps
+          make -C bpf-loader test
+
     - name: Code coverage using Codecov
       run: bash <(curl -s https://codecov.io/bash)
 

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -5,9 +5,6 @@ on:
   pull_request:
     branches: "*"
 
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
-
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
@@ -44,3 +41,23 @@ jobs:
       - name: test examples
         run:  |
               make -C examples/tests test
+      
+      - uses: uraimo/run-on-arch-action@v2
+        name: test examples on aarch64
+        id: runcmd
+        with:
+          arch: aarch64
+          distro: ubuntu_latest
+          dockerRunArgs: |
+            -v `pwd`/:/usr/eunomia-bpf/
+          githubToken: ${{ github.token }}
+          run: |
+            apt-get update
+            apt-get install make
+            cd /usr/eunomia-bpf/
+            make -C bpf-loader install-deps
+
+            make -C examples/tests install-deps
+            make -C examples/tests install-wasm-clang
+            make -C examples
+            make -C examples/tests test

--- a/.github/workflows/wasm-runtime.yml
+++ b/.github/workflows/wasm-runtime.yml
@@ -39,6 +39,21 @@ jobs:
         cd wasm-runtime/
         sudo make test
 
+    - uses: uraimo/run-on-arch-action@v2
+      name: run unit tests on aarch64
+      id: runcmd
+      with:
+        arch: aarch64
+        distro: ubuntu_latest
+        dockerRunArgs: |
+          -v `pwd`/:/usr/eunomia-bpf/
+        githubToken: ${{ github.token }}
+        run: |
+          apt-get update
+          apt-get install git make
+          make -C bpf-loader install-deps
+          cd wasm-runtime/ && make test
+
     # Wait https://github.com/eunomia-bpf/wasm-bpf/pull/5 
     # - name: run wasm generate tests
     #   run: |

--- a/compiler/dockerfile
+++ b/compiler/dockerfile
@@ -6,7 +6,7 @@ COPY . /usr/local/src
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
         libelf1 libelf-dev zlib1g-dev libclang-13-dev \
-        make wget cargo curl python2 clang llvm && \
+        make wget cargo curl python2 clang llvm git && \
     apt-get install -y --no-install-recommends ca-certificates	&& \
 	update-ca-certificates	&& \
     apt-get clean && \
@@ -22,8 +22,8 @@ RUN wget --progress=dot:giga --no-check-certificate \
 RUN cp /usr/bin/python2 /usr/bin/python
 
 ARG CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
-RUN make ecc    && \
-    make -C compiler install    && \
+RUN export CARGO_NET_GIT_FETCH_WITH_CLI=true && \
+    make ecc    && \
     rm -rf compiler/cmd/target
 
 WORKDIR /usr/local/src/compiler


### PR DESCRIPTION
Doing ci testing in aarch64 environment with [run-on-arch-action](https://github.com/uraimo/run-on-arch-action), it's really slow, is there any other way to replace it?