### PR TITLE
ecli/oci: add ghcr token login

### DIFF
--- a/.github/workflows/ecli.yaml
+++ b/.github/workflows/ecli.yaml
@@ -44,7 +44,7 @@ jobs:
       if:   github.event_name == 'push' && github.ref == 'refs/heads/master'
       id: set_version
       uses: actions/github-script@v6
-      
+
       with:
         result-encoding: string
         script: |
@@ -52,25 +52,25 @@ jobs:
             owner: context.repo.owner,
             repo: context.repo.repo,
           });
-          
+
           const { data: tags } = await github.rest.repos.listTags({
             owner: context.repo.owner,
             repo: context.repo.repo
           });
-          
+
           if (releases.length === 0) { return "v0.0.1"; }
-          
+
           function increase_v(version) {
             const parts = version.split(".");
             const last = parseInt(parts[2]) + 1;
             const next_version = `${parts[0]}.${parts[1]}.${last.toString()}`;
             return next_version;
           }
-          
+
           const latest_release_tag = releases[0].tag_name;
-          
+
           const tag = tags.find(tag => tag.commit.sha === context.sha);
-          
+
           return tag ? tag.name : increase_v(latest_release_tag)
 
     - name: install deps
@@ -96,6 +96,18 @@ jobs:
 
     - name: make ecli
       run:  make ecli
+
+    - name: ecli oci login gh cache test
+      shell: bash
+      run: |
+        mkdir -p ~/.config/gh
+        cat > ~/.config/gh/hosts.yml << 'EOF'
+        github.com:
+          user: eunomia-bpf
+          oauth_token: ${{ secrets.GITHUB_TOKEN }}
+          git_protocol: ssh
+        EOF
+        ./ecli/target/release/ecli login
 
     - name: Package
       if:   github.event_name == 'push' && github.ref == 'refs/heads/master'

--- a/documents/src/ecli/index.md
+++ b/documents/src/ecli/index.md
@@ -33,4 +33,7 @@ For details, see [ecc-btfgen](../ecc/usage.md#options)
 - push - Push a container to an OCI registry.
 - pull - Pull a container from an OCI registry.
 - login - Login to an OCI registry.
+    `ecli` will check [gh](https://cli.github.com/) cache and `GITHUB_TOKEN`
+    env when you login to ghcr.io, either one can be logged into ghcr without entering a token.
 - logout - Logout from an OCI registry.
+    `ecli logout xxx` will remove identity certificates stored under `~/.eunomia`.

--- a/ecli/Cargo.lock
+++ b/ecli/Cargo.lock
@@ -785,12 +785,14 @@ dependencies = [
  "clap 4.2.2",
  "env_logger 0.9.3",
  "eunomia-rs",
+ "home",
  "log",
  "oci-distribution",
  "reqwest",
  "rpassword",
  "serde",
  "serde_json",
+ "serde_yaml",
  "signal-hook",
  "tar",
  "tokio",
@@ -2524,6 +2526,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9d684e3ec7de3bf5466b32bd75303ac16f0736426e5a4e0d6e489559ce1249c"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3060,6 +3075,12 @@ name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1865806a559042e51ab5414598446a5871b561d21b6764f2eabb0dd481d880a6"
 
 [[package]]
 name = "url"

--- a/ecli/Cargo.toml
+++ b/ecli/Cargo.toml
@@ -10,10 +10,12 @@ base64 = "0.21.0"
 clap = { version = "4.0.32", features = ["derive"] }
 eunomia-rs = { path = "../eunomia-sdks/eunomia-rs" }
 env_logger = "0.9.0"
+home = "0.5.4"
 log = "0.4.17"
 rpassword = "7.2.0"
 reqwest = { version = "0.11.12", features = ["blocking"] }
 serde = { version = "1.0.151", features = ["derive"] }
+serde_yaml = "0.9.21"
 serde_json = "1.0.91"
 url = "2.3.1"
 tokio = { version = "1.24.2", features = ["rt-multi-thread"] }

--- a/ecli/src/main.rs
+++ b/ecli/src/main.rs
@@ -57,13 +57,13 @@ pub enum Action {
     /// login to oci registry
     Login {
         /// oci login url
-        #[arg()]
+        #[arg(default_value = ("https://ghcr.io").to_string())]
         url: String,
     },
     /// logout from registry
     Logout {
         /// oci logout url
-        #[arg()]
+        #[arg(default_value = ("ghcr.io").to_string())]
         url: String,
     },
 }

--- a/ecli/src/oci/auth/login.rs
+++ b/ecli/src/oci/auth/login.rs
@@ -3,9 +3,12 @@
 //! Copyright (c) 2023, eunomia-bpf
 //! All rights reserved.
 //!
-use std::io::{stdin, stdout, Write};
+use std::io::{stdin, Write};
+use std::{env, fs};
 
 use oci_distribution::{secrets::RegistryAuth, Reference, RegistryOperation};
+use rpassword::prompt_password;
+use serde_yaml::{self, Value};
 use url::Url;
 
 use crate::{
@@ -15,30 +18,70 @@ use crate::{
 
 use super::{get_auth_save_file, AuthInfo, LoginInfo};
 
-fn read_login_user_pwd() -> (String, String) {
-    print!("username: ");
-    let _ = stdout().flush();
-    (
-        stdin().lines().next().unwrap().unwrap(),
-        rpassword::prompt_password("password: ").unwrap(),
-    )
+fn read_login_user() -> String {
+    print!("username:");
+    std::io::stdout().flush().unwrap();
+    stdin().lines().next().unwrap().unwrap()
 }
-/// Login into an OCI registry
-/// Will prompt and read username and password from stdin
-pub async fn login(u: String) -> EcliResult<()> {
-    let url = Url::parse(u.as_str()).map_err(|e| EcliError::ParamErr(e.to_string()))?;
+
+fn read_login_password() -> String {
+    prompt_password("password:").unwrap()
+}
+
+fn read_login_token() -> String {
+    print!("token:");
+    std::io::stdout().flush().unwrap();
+    stdin().lines().next().unwrap().unwrap()
+}
+
+fn get_gh_env_token() -> (String, String) {
+    let gh_config_path = home::home_dir().unwrap().join(".config/gh/hosts.yml");
+    if gh_config_path.exists() {
+        let gh_config = fs::File::open(gh_config_path).unwrap();
+        let config: Value = serde_yaml::from_reader(gh_config).unwrap();
+        return (
+            config["github.com"]["user"].as_str().unwrap().to_string(),
+            config["github.com"]["oauth_token"]
+                .as_str()
+                .unwrap()
+                .to_string(),
+        );
+    }
+    let username = read_login_user();
+
+    static GITHUB_TOKEN: &str = "GITHUB_TOKEN";
+    if let Ok(token) = env::var(GITHUB_TOKEN) {
+        return (username, token);
+    }
+
+    return (username, read_login_token());
+}
+
+async fn login_registry(url: Url, username: &str, token: &str) -> EcliResult<()> {
     let Some(host) = url.host_str() else {
         return Err(EcliError::ParamErr("url format incorrect".to_string()))
     };
-
     let mut auth_info = AuthInfo::get()?;
-    let (username, password) = read_login_user_pwd();
-    let login_info = LoginInfo::new(host, username.as_str(), password.as_str());
+    let login_info = LoginInfo::new(host, username, token);
 
     v2_login(&url, &login_info).await?;
     auth_info.set_login_info(login_info);
     auth_info.write_to_file(&mut get_auth_save_file()?)?;
     println!("Login success");
+    Ok(())
+}
+
+/// Login into an OCI registry
+/// Will prompt and read username and password from stdin
+pub async fn login(u: String) -> EcliResult<()> {
+    let url = Url::parse(u.as_str()).map_err(|e| EcliError::ParamErr(e.to_string()))?;
+
+    if url.as_str() == "https://ghcr.io/" {
+        let (user, token) = get_gh_env_token().into();
+        login_registry(url, &user, &token).await?;
+    } else {
+        login_registry(url, &read_login_user(), &read_login_password()).await?;
+    }
     Ok(())
 }
 /// Login into an OCI registry


### PR DESCRIPTION
I misread the issues repository... But this is still a useful feature.

Login ghcr with 'gh' cache or `GITHUB_TOKEN` env.

ghcr.io only support token login, so the previous user password won't work.

now if `$HOME/.config/gh/hosts.yml` exist, it will auto login.
```sh
ecli login https://ghcr.io/
Login success
```