### PR TITLE
Fixes #196

### DIFF
--- a/examples/bpftools/bashreadline/bashreadline.bpf.c
+++ b/examples/bpftools/bashreadline/bashreadline.bpf.c
@@ -23,7 +23,7 @@ struct {
  * specified (and auto-attach is not possible) or the above format is specified for
  * auto-attach.
  */
-SEC("uprobe//bin/bash:readline")
+SEC("uretprobe//bin/bash:readline")
 int BPF_KRETPROBE(printret, const void* ret) {
     struct str_t data;
     char comm[TASK_COMM_LEN];


### PR DESCRIPTION
This PR closes #196 

It changes the attachpoint of `bashreadline` to `uretprobe`