### PR TITLE
Bump version of ecli

### DIFF
--- a/ecli/client/Cargo.toml
+++ b/ecli/client/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "ecli"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "The client cli wrapper of ecli"
 license = "MIT"
 
 [dependencies]
-ecli-lib = { path = "../ecli-lib", version = "0.2.0" }
+ecli-lib = { path = "../ecli-lib", version = "0.2.1" }
 tokio = { version = "1.24.2", features = ["rt-multi-thread"] }
 clap = { version = "4.0.32", features = ["derive"] }
 ctrlc = "3.2.5"

--- a/ecli/ecli-lib/Cargo.toml
+++ b/ecli/ecli-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ecli-lib"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "The core implementation of ecli"
 license = "MIT"

--- a/ecli/server/Cargo.toml
+++ b/ecli/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ecli-server"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "The server cli wrapper of ecli"
 license = "MIT"
@@ -8,7 +8,7 @@ license = "MIT"
 [dependencies]
 ecli-lib = { path = "../ecli-lib", features = [
     "http-server",
-], version = "0.2.0" }
+], version = "0.2.1" }
 tokio = { version = "1.24.2", features = ["rt-multi-thread"] }
 clap = { version = "4.0.32", features = ["derive"] }
 ecli-server-codegen = { path = "../server-codegen" }


### PR DESCRIPTION
`bpf-loader-rs` was updated, so I just publish a new version `ecli`