### PR TITLE
Rename `ecli` to `ecli-rs`

### DIFF
--- a/ecli/client/Cargo.toml
+++ b/ecli/client/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "ecli"
+name = "ecli-rs"
 version = "0.2.1"
 edition = "2021"
 description = "The client cli wrapper of ecli"


### PR DESCRIPTION
The name `ecli` is occupied, so we rename the client to `ecli-rs`