### PR TITLE
Fix bin-name-issue

### DIFF
--- a/.github/workflows/ecli.yaml
+++ b/.github/workflows/ecli.yaml
@@ -114,14 +114,14 @@ jobs:
           oauth_token: ${{ secrets.GITHUB_TOKEN }}
           git_protocol: ssh
         EOF
-        ./ecli/target/release/ecli login
+        ./ecli/target/release/ecli-rs login
 
     - name: Package
       if:   github.event_name == 'push' && github.ref == 'refs/heads/master'
       shell: bash
       run: |
         mkdir release
-        cp ecli/target/release/ecli ./release/
+        cp ecli/target/release/ecli-rs ./release/ecli
         cd release
         tar czvf ./ecli-${{ matrix.target }}-${{ steps.set_version.outputs.result }}.tar.gz ecli
 

--- a/ecli/Makefile
+++ b/ecli/Makefile
@@ -7,7 +7,7 @@ install:
 	rm -rf target/
 	cargo build --release
 	mkdir -p ~/.eunomia/bin
-	cp ./target/release/ecli ~/.eunomia/bin/ecli
+	cp ./target/release/ecli-rs ~/.eunomia/bin/ecli
 
 install-deps:
 	sudo apt install libssl-dev

--- a/ecli/dockerfile
+++ b/ecli/dockerfile
@@ -3,7 +3,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends libelf1 \
     && rm -rf /var/lib/apt/lists/*
 
-COPY ./target/release/ecli /root/ecli
+COPY ./target/release/ecli-rs /root/ecli
 
 WORKDIR /root
 

--- a/ecli/tests/api-test.py
+++ b/ecli/tests/api-test.py
@@ -18,7 +18,7 @@ def run(cmd):
 
 if __name__ == "__main__":
     log_level = "RUST_LOG=info "
-    cli_bin = ["ecli/target/release/ecli"]
+    cli_bin = ["ecli/target/release/ecli-rs"]
     server_bin = ["ecli/target/release/eserver"]
     env_dbg = os.environ.copy()
     env_dbg["RUST_LOG"] = "info"

--- a/examples/tests/Makefile
+++ b/examples/tests/Makefile
@@ -15,7 +15,7 @@ install-deps:
 	make -C $(ECC_DIR)
 	make -C $(ECC_DIR) install
 	make -C $(ECLI_DIR) install
-	cp $(ECLI_DIR)target/release/ecli ./ecli
+	cp $(ECLI_DIR)target/release/ecli-rs ./ecli
 
 # test with the files in bpf-loader
 TEST_CASES_DIRS=$(shell ls -l $(TEST_EXAMPLE_DIR) | grep ^d | awk '{print $$9}')


### PR DESCRIPTION
Rename the client crate from `ecli` to `ecli-rs` caused some tasks failed to run. This PR fixes that.