### PR TITLE
Add a workflow to create static libs

### DIFF
--- a/.github/workflows/build-static-bpf-loader-c-wrapper.yml
+++ b/.github/workflows/build-static-bpf-loader-c-wrapper.yml
@@ -35,7 +35,7 @@ jobs:
         llvm-ar x libelf.a
         llvm-ar x libz.a
         rm *.a
-        llvm-ar q libeunomia *.o
+        llvm-ar q libeunomia.a *.o
 
     - name: Upload build result
       uses: actions/upload-artifact@v2.3.1

--- a/.github/workflows/build-static-bpf-loader-c-wrapper.yml
+++ b/.github/workflows/build-static-bpf-loader-c-wrapper.yml
@@ -2,9 +2,9 @@ name: Build the static library of `bpf-loader-c-wrapper`
 
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
   pull_request:
-    branches: [ main ]
+    branches: [ master ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/build-static-bpf-loader-c-wrapper.yml
+++ b/.github/workflows/build-static-bpf-loader-c-wrapper.yml
@@ -24,7 +24,7 @@ jobs:
 
     - name: Build bpf-loader-c-wrapper
       run: |
-          cd bpf-loader-lib/bpf-loader-c-wrapper
+          cd bpf-loader-rs/bpf-loader-c-wrapper
           cargo build --release
     - name: Merge several archives
       run: |

--- a/.github/workflows/build-static-bpf-loader-c-wrapper.yml
+++ b/.github/workflows/build-static-bpf-loader-c-wrapper.yml
@@ -28,7 +28,7 @@ jobs:
           cargo build --release
     - name: Merge several archives
       run: |
-        cp ./runtime/target/release/libeunomia.a .
+        cp ./bpf-loader-rs/target/release/libeunomia.a .
         cp /usr/lib/x86_64-linux-gnu/libz.a .
         cp /usr/lib/x86_64-linux-gnu/libelf.a .
         llvm-ar x libeunomia.a

--- a/.github/workflows/build-static-bpf-loader-c-wrapper.yml
+++ b/.github/workflows/build-static-bpf-loader-c-wrapper.yml
@@ -1,0 +1,43 @@
+name: Build the static library of `bpf-loader-c-wrapper`
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: 'recursive'
+
+    - name: install deps
+      run: |
+          sudo make install-deps
+
+    - name: Build bpf-loader-c-wrapper
+      run: |
+          cd bpf-loader-lib/bpf-loader-c-wrapper
+          cargo build --release
+    - name: Merge several archives
+      run: |
+        cp ./runtime/target/release/libeunomia.a .
+        cp /usr/lib/x86_64-linux-gnu/libz.a .
+        cp /usr/lib/x86_64-linux-gnu/libelf.a .
+        llvm-ar x libeunomia.a
+        llvm-ar x libelf.a
+        llvm-ar x libz.a
+        rm *.a
+        llvm-ar q libeunomia *.o
+
+    - name: Upload build result
+      uses: actions/upload-artifact@v2.3.1
+      with:
+        path: "libeunomia.a"

--- a/bpf-loader-rs/bpf-loader-c-wrapper/eunomia-bpf.h
+++ b/bpf-loader-rs/bpf-loader-c-wrapper/eunomia-bpf.h
@@ -7,7 +7,7 @@
 extern "C" {
 #endif
 enum export_format_type {
-    EXPORT_PLANT_TEXT,
+    EXPORT_PLAIN_TEXT,
     EXPORT_JSON,
     EXPORT_RAW_EVENT,
 };


### PR DESCRIPTION
This pull request adds a workflow to create a static version of `bpf-loader-c-wrapper`, thus it can be used for ecc to produce standalone executables.