### PR TITLE
fix ecli ctrlc

### DIFF
--- a/ecli/client/src/main.rs
+++ b/ecli/client/src/main.rs
@@ -7,7 +7,7 @@ use ecli_lib::{
         pull, push, PullArgs, PushArgs,
     },
 };
-use std::process;
+use std::sync::atomic::Ordering;
 
 #[cfg(feature = "http")]
 mod http_client;
@@ -91,7 +91,7 @@ async fn main() -> Result<()> {
         .map_err(|e| Error::Log(format!("Failed to start logger: {}", e)))?;
 
     ctrlc::set_handler(move || {
-        process::exit(0);
+        native_client::TERMINATED.store(true, Ordering::Relaxed);
     })
     .ok();
     let args = Args::parse();


### PR DESCRIPTION
ctrl-c won't make ecli just exit now but give it time to detach BPF program before exit.

This is useful when the BPF program(e.g. xdp and tc) won't be detached automatically with the exit of ecli process.

# Test

Use `bpftool net show` to find out whether the tc program will be detached after the ecli exit.