### PR TITLE
Try to fix crates.io issue

### DIFF
--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -64,7 +64,9 @@ $(BPFTOOL):
 
 $(ECC): $(BPFTOOL)
 	cd cmd && cargo build --release
-	ln -s ./cmd/workspace workspace
+	cargo install cargo-out-dir
+	cd cmd && cargo build # Run a debug build to create the workspace directory 
+	cd cmd && cp -r `cargo out-dir`/workspace ..
 	cp $(ECC) workspace/bin/ecc
 
 install:

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -5,7 +5,7 @@ CLANG ?= clang
 LLVM_STRIP ?= llvm-strip
 BPFTOOL_SRC := $(abspath ../third_party/bpftool)
 BPFTOOL := $(BPFTOOL_SRC)/src/bpftool
-ECC := cmd/target/release/ecc
+ECC := cmd/target/release/ecc-rs
 ARCH := $(shell uname -m | sed 's/x86_64/x86/' | sed 's/aarch64/arm64/' | sed 's/ppc64le/powerpc/' | sed 's/mips.*/mips/' | sed 's/riscv64/riscv/')
 VMLINUX := ../third_party/vmlinux/$(ARCH)/vmlinux.h
 # Use our own libbpf API headers and Linux UAPI headers distributed with
@@ -67,7 +67,7 @@ $(ECC): $(BPFTOOL)
 	cargo install cargo-out-dir
 	cd cmd && cargo build # Run a debug build to create the workspace directory 
 	cd cmd && cp -r `cargo out-dir`/workspace ..
-	cp $(ECC) workspace/bin/ecc
+	cp $(ECC) workspace/bin/ecc-rs
 
 install:
 	rm -rf ~/.eunomia && cp -r workspace ~/.eunomia

--- a/compiler/cmd/Cargo.lock
+++ b/compiler/cmd/Cargo.lock
@@ -218,6 +218,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -519,6 +539,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall 0.2.16",
+ "thiserror",
+]
+
+[[package]]
 name = "regex"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -564,6 +595,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
+ "shellexpand",
  "syn 1.0.107",
  "walkdir",
 ]
@@ -663,6 +695,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "shellexpand"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ccc8076840c4da029af4f87e4e8daeb0fca6b87bbb02e10cb60b791450e11e4"
+dependencies = [
+ "dirs",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -712,6 +753,26 @@ dependencies = [
  "redox_syscall 0.3.5",
  "rustix",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.16",
 ]
 
 [[package]]

--- a/compiler/cmd/Cargo.toml
+++ b/compiler/cmd/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.3.3"
 edition = "2021"
 license = "MIT"
 description = "A compiler to produce ebpf programs that can be run by ecli"
+repository = "https://github.com/eunomia-bpf/eunomia-bpf"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/compiler/cmd/Cargo.toml
+++ b/compiler/cmd/Cargo.toml
@@ -17,7 +17,7 @@ serde_yaml = "0.9"
 flate2 = "1.0"
 base64 = "0.13.1"
 clang = "2.0.0"
-rust-embed = "6.4.2"
+rust-embed = { version = "6.4.2", features = ["interpolate-folder-path"] }
 tar = "0.4.38"
 fs_extra = "1.3.0"
 tempfile = "3.5.0"

--- a/compiler/cmd/Cargo.toml
+++ b/compiler/cmd/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "ecc"
+name = "ecc-rs"
 version = "0.3.3"
 edition = "2021"
 license = "MIT"

--- a/compiler/cmd/build.rs
+++ b/compiler/cmd/build.rs
@@ -114,6 +114,8 @@ fn main() -> anyhow::Result<()> {
         &CopyOptions::default(),
     )
     .with_context(|| anyhow!("Failed to copy libbpf headers"))?;
+    // Avoid copying the .git folder
+    std::fs::remove_dir_all(workdir().join(vmlinux_repodir()).join(".git"))?;
     fs_extra::dir::copy(
         workdir().join(vmlinux_repodir()),
         workspace_path.join("include"),

--- a/compiler/cmd/build.rs
+++ b/compiler/cmd/build.rs
@@ -87,10 +87,8 @@ fn main() -> anyhow::Result<()> {
     println!("cargo:rerun-if-env-changed=BPFTOOL_REF");
     println!("cargo:rerun-if-env-changed=VMLINUX_REPO");
     println!("cargo:rerun-if-env-changed=VMLINUX_REF");
-    println!("cargo:rerun-if-changed=workspace");
 
-    let workspace_path =
-        PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap()).join("workspace");
+    let workspace_path = workdir().join("workspace");
 
     fetch_and_build_bpftool()?;
     fetch_git_repo(&vmlinux_repo(), &vmlinux_ref(), &vmlinux_repodir())

--- a/compiler/cmd/src/compile_bpf.rs
+++ b/compiler/cmd/src/compile_bpf.rs
@@ -140,7 +140,7 @@ fn do_compile(args: &Options, temp_source_file: &str) -> Result<()> {
     }
 
     // add version
-    meta_json["eunomia_version"] = json!(include_str!("../../../VERSION"));
+    meta_json["eunomia_version"] = json!(env!("CARGO_PKG_VERSION"));
 
     let meta_config_str = if args.compile_opts.yaml {
         serde_yaml::to_string(&meta_json)?

--- a/compiler/cmd/src/config.rs
+++ b/compiler/cmd/src/config.rs
@@ -380,7 +380,7 @@ pub fn get_wasm_header_path(args: &Options) -> String {
 
 /// embed workspace
 #[derive(RustEmbed)]
-#[folder = "workspace/"]
+#[folder = "$OUT_DIR/workspace/"]
 struct Workspace;
 
 pub fn init_eunomia_workspace(tmp_workspace: &TempDir) -> Result<()> {

--- a/examples/tests/Makefile
+++ b/examples/tests/Makefile
@@ -2,7 +2,7 @@ TEST_EXAMPLE_DIR ?= ../bpftools/
 TEST_TIME ?= 2
 ECLI_DIR ?= ../../ecli/
 ECC_DIR ?= ../../compiler/
-ECC_BIN ?= ../../compiler/workspace/bin/ecc
+ECC_BIN ?= ../../compiler/workspace/bin/ecc-rs
 
 # TODO: maybe use the compile docker to test?
 


### PR DESCRIPTION
`ecc` still can't be published to crates.io due to its modification to the source folder. This PR fixes it.