### PR TITLE
Use local path to specify the dependency of `ecli-lib`

### DIFF
--- a/ecli/ecli-lib/Cargo.toml
+++ b/ecli/ecli-lib/Cargo.toml
@@ -37,7 +37,7 @@ thiserror = "1.0.40"
 tempdir = "0.3.7"
 
 # These deps are only needed when `native-client` feature is enabled
-bpf-loader-lib = { version = "0.1.3", optional = true }
+bpf-loader-lib = { path = "../../bpf-loader-rs/bpf-loader-lib", version = "0.1.3", optional = true }
 wasm-bpf-rs = { version = "0.3.2", optional = true }
 tar = { version = "0.4", optional = true }
 


### PR DESCRIPTION
Changes the dependency description of `bpf-loader-lib` to `bpf-loader-lib = { path = "../../bpf-loader-rs/bpf-loader-lib", version = "0.1.3", optional = true }` in `ecli-lib`

Other crates already has local-specified dependency, so no changes made to them