### PR TITLE
CI: fix the name of release binary

### DIFF
--- a/.github/workflows/ecc-image.yml
+++ b/.github/workflows/ecc-image.yml
@@ -59,7 +59,5 @@ jobs:
             ghcr.io/${{ env.REPO_OWNER }}/ecc-aarch64:latest
           push: true
 
-
-
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/ecc.yml
+++ b/.github/workflows/ecc.yml
@@ -124,9 +124,9 @@ jobs:
       shell: bash
       run: |
         mkdir release
-        cp compiler/workspace/bin/ecc-rs ./release/
+        cp compiler/workspace/bin/ecc-rs ./release/ecc
         cd release
-        tar czvf ./ecc-${{ matrix.target }}-${{ steps.set_version.outputs.result }}.tar.gz ecc-rs
+        tar czvf ./ecc-${{ matrix.target }}-${{ steps.set_version.outputs.result }}.tar.gz ecc
 
     - name: Publish
       if:   github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository_owner == 'eunomia-bpf'
@@ -134,7 +134,7 @@ jobs:
       with:
           files: |
             release/ecc-${{ matrix.target }}-${{ steps.set_version.outputs.result }}.tar.gz
-            release/ecc-rs
+            release/ecc
           prerelease: false
           tag_name: ${{ steps.set_version.outputs.result }}
           generate_release_notes: true

--- a/documents/src/blog/lmp-eunomia.md
+++ b/documents/src/blog/lmp-eunomia.md
@@ -349,5 +349,5 @@ ORAS 的工作原理与您可能已经熟悉的工具(如 docker)类似。它允
 - [当 Wasm 遇见 eBPF：使用 WebAssembly 编写、分发、加载运行 eBPF 程序 | 龙蜥技术 (qq.com)](https://mp.weixin.qq.com/s/ryT7OqWngCjcCkfeSKjutA)
 - [开放容器标准(OCI) 内部分享 (xuanwo.io)](https://xuanwo.io/2019/08/06/oci-intro/)
 - [WebAssembly | MDN (mozilla.org)](https://developer.mozilla.org/zh-CN/docs/WebAssembly)
-- [非网络嵌入 - WebAssembly 中文网|Wasm 中文文档](http://webassembly.org.cn/docs/non-web/)
+- [WebAssembly 中文网|Wasm 中文文档](https://webassembly.org/specs/)
 - [eBPF 在线学习平台：bolipi.com/ebpf/home/online](https://bolipi.com/ebpf/home/online)


### PR DESCRIPTION
# Pull Request Template

## Description

Fix the name of ecc in release binary, so that

```
wget https://github.com/eunomia-bpf/eunomia-bpf/releases/latest/download/ecc && chmod +x ./ecc
```

can work.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
