### PR TITLE
Fixes docker image issue (#254)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,5 +3,5 @@
 	url = https://github.com/eunomia-bpf/bpftool
 [submodule "third_party/vmlinux"]
 	path = third_party/vmlinux
-	url = git@github.com:eunomia-bpf/vmlinux.git
+	url = https://github.com/eunomia-bpf/vmlinux
 	branch = main

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -96,9 +96,8 @@ test:
 # 	$(Q)SOURCE_DIR=$(SOURCE_DIR) make -C workspace/scripts generate
 
 .PHONY: build
-build:
-	export PATH=$PATH:~/.eunomia/bin
-	$(Q)workspace/bin/ecc $(shell ls $(SOURCE_DIR)*.bpf.c) $(shell ls -h1 $(SOURCE_DIR)*.h | grep -v .*\.bpf\.h)
+build-ebpf-program:
+	$(Q)~/.eunomia/bin/ecc-rs $(shell ls $(SOURCE_DIR)*.bpf.c) $(shell ls -h1 $(SOURCE_DIR)*.h | grep -v .*\.bpf\.h)
 
 .PHONY: docker
 docker: wasi-sdk-16.0-linux.tar.gz

--- a/compiler/dockerfile
+++ b/compiler/dockerfile
@@ -33,4 +33,4 @@ RUN make ecc    && \
 WORKDIR /usr/local/src/compiler
 
 ENTRYPOINT ["make"]
-CMD ["build"]
+CMD ["build-ebpf-program"]


### PR DESCRIPTION
This PR fixes the issue #254.

It was caused by the Makefile not updated after we changed the position of the workspace directory when building `ecc`.

In order to build the workspace in the build script, we have to move the workspace directory into the cargo out directory, causing the outdated Makefile failing to use the `ecc` exists in the workspace of the `ecc` directory.

This PR makes the Makefile to use the `ecc` installed at `~/.eunomia/bin/ecc`