### PR TITLE
Allow `cargo clean` to fail

### DIFF
--- a/compiler/dockerfile
+++ b/compiler/dockerfile
@@ -28,7 +28,7 @@ ARG CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 
 RUN make ecc    && \
     make -C compiler install    && \
-    cd compiler/cmd && cargo clean
+    cd compiler/cmd && (cargo clean || true)
 
 WORKDIR /usr/local/src/compiler
 


### PR DESCRIPTION
Allow `cargo clean` to fail, trying to make the image publish CI pass