### PR TITLE
Change the order of judging the url type

### DIFF
--- a/ecli/client/Cargo.toml
+++ b/ecli/client/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "ecli-rs"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 description = "The client cli wrapper of ecli"
 license = "MIT"
 
 [dependencies]
-ecli-lib = { path = "../ecli-lib", version = "0.2.4" }
+ecli-lib = { path = "../ecli-lib", version = "0.2.5" }
 tokio = { version = "1.24.2", features = ["rt-multi-thread"] }
 clap = { version = "4.0.32", features = ["derive"] }
 ctrlc = { version = "3.2.5", optional = true }

--- a/ecli/client/src/helper.rs
+++ b/ecli/client/src/helper.rs
@@ -26,7 +26,7 @@ pub async fn load_prog_buf_and_guess_type(
         }
     } else {
         let (buf, prog_type) = try_load_program_buf_and_guess_type(path).await?;
-        let prog_type = prog_type.or(user_prog_type).ok_or_else(|| {
+        let prog_type = user_prog_type.or(prog_type).ok_or_else(|| {
             Error::InvalidParam(
                 "Failed to guess the program type, please specify it through -p argument"
                     .to_string(),

--- a/ecli/ecli-lib/Cargo.toml
+++ b/ecli/ecli-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ecli-lib"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 description = "The core implementation of ecli"
 license = "MIT"

--- a/ecli/ecli-lib/src/oci/wasm/mod.rs
+++ b/ecli/ecli-lib/src/oci/wasm/mod.rs
@@ -5,7 +5,7 @@
 //!
 use std::path::Path;
 
-use log::info;
+use log::{debug, info};
 use oci_distribution::{secrets::RegistryAuth, Client, Reference};
 use tokio::{fs::File, io::AsyncReadExt};
 use url::Url;
@@ -41,7 +41,7 @@ pub fn parse_img_url(url: &str) -> Result<(Client, RegistryAuth, Reference, Stri
             }
         }
     };
-
+    debug!("Parsed auth info: {:?}", auth);
     let client = get_client(&img_url)?;
     let Some(host) = img_url.host() else {
         return Err(Error::InvalidParam(format!("invalid url: {}",url)))

--- a/ecli/server/Cargo.toml
+++ b/ecli/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ecli-server"
-version = "0.2.3"
+version = "0.2.5"
 edition = "2021"
 description = "The server cli wrapper of ecli"
 license = "MIT"
@@ -8,7 +8,7 @@ license = "MIT"
 [dependencies]
 ecli-lib = { path = "../ecli-lib", features = [
     "http-server",
-], version = "0.2.3" }
+], version = "0.2.5" }
 tokio = { version = "1.24.2", features = ["rt-multi-thread"] }
 clap = { version = "4.0.32", features = ["derive"] }
 ecli-server-codegen = { path = "../server-codegen", version = "1.0.0" }


### PR DESCRIPTION
This PR changes the order to judge the user-provided URL to ecli. 
It will use the following order:
- Try to regard the string as a local file path, and try to parse that as a JSON or tar
- Try to treat the string as a HTTP url, and try to parse the downloaded file as a JSON or tar
- Try to regard the string as an OCI url