### PR TITLE
Add compatibility to older ecli versions

### DIFF
--- a/ecli/client/src/main.rs
+++ b/ecli/client/src/main.rs
@@ -1,4 +1,4 @@
-use clap::{Parser, Subcommand};
+use clap::{error::ErrorKind, CommandFactory, Parser, Subcommand};
 
 use ecli_lib::{
     error::{Error, Result},
@@ -14,6 +14,28 @@ mod http_client;
 mod native_client;
 
 mod helper;
+
+#[derive(clap::clap_derive::Args)]
+struct RunProgArgs {
+    /// json output format
+    #[arg(
+        long,
+        short = 'j',
+        default_value_t = false,
+        help = "Let the ebpf program prints the logs in json format. Only works for JSON program"
+    )]
+    json: bool,
+    /// program path or url
+    #[arg(
+        allow_hyphen_values = true,
+        help = "ebpf program URL or local path, set it `-` to read the program from stdin"
+    )]
+    prog: String,
+    #[arg(help = "Extra args to the program; For wasm program, it will be passed directly to it; For JSON program, it will be passed to the generated argument parser", action = clap::ArgAction::Append)]
+    extra_args: Vec<String>,
+    #[clap(long, short, help = "Manually specity the program type", value_parser = helper::prog_type_value_parser)]
+    prog_type: Option<ecli_lib::config::ProgramType>,
+}
 
 /// ecli subcommands, including run, push, pull, login, logout.
 #[derive(Subcommand)]
@@ -79,7 +101,17 @@ pub enum Action {
 #[derive(Parser)]
 struct Args {
     #[command(subcommand)]
-    action: Action,
+    action: Option<Action>,
+    /// program path or url
+    #[cfg(feature = "native")]
+    #[arg(
+        allow_hyphen_values = true,
+        help = "Not preferred. Only for compatibility to older versions. Ebpf program URL or local path, set it `-` to read the program from stdin"
+    )]
+    prog: Option<String>,
+    #[cfg(feature = "native")]
+    #[arg(help = "Not preferred. Only for compatibility to older versions. Extra args to the program; For wasm program, it will be passed directly to it; For JSON program, it will be passed to the generated argument parser", action = clap::ArgAction::Append)]
+    extra_args: Vec<String>,
 }
 
 #[tokio::main]
@@ -98,31 +130,46 @@ async fn main() -> Result<()> {
         .ok();
     }
     let args = Args::parse();
+
+    #[cfg(feature = "native")]
+    {
+        if let Some(prog) = args.prog {
+            native_client::run_native(false, prog, &args.extra_args, None).await?;
+            return Ok(());
+        }
+    }
+
     match args.action {
         #[cfg(feature = "native")]
-        Action::Run {
+        Some(Action::Run {
             json,
             prog,
             extra_args,
             prog_type,
-        } => native_client::run_native(json, prog, &extra_args, prog_type).await,
-        Action::Push { image, module } => {
+        }) => native_client::run_native(json, prog, &extra_args, prog_type).await,
+        Some(Action::Push { image, module }) => {
             push(PushArgs {
                 file: module,
                 image_url: image,
             })
             .await
         }
-        Action::Pull { image, output } => {
+        Some(Action::Pull { image, output }) => {
             pull(PullArgs {
                 write_file: output,
                 image_url: image,
             })
             .await
         }
-        Action::Login { url } => login(url).await,
-        Action::Logout { url } => logout(url),
+        Some(Action::Login { url }) => login(url).await,
+        Some(Action::Logout { url }) => logout(url),
         #[cfg(feature = "http")]
-        Action::Client(cmd) => http_client::handle_client_command(cmd).await,
+        Some(Action::Client(cmd)) => http_client::handle_client_command(cmd).await,
+        None => Args::command()
+            .error(
+                ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand,
+                "Either use subcommand, or directly provide program URL",
+            )
+            .exit(),
     }
 }


### PR DESCRIPTION
This pull request make the current ecli compatible to the older running command, i.e:
```bash
ecli https://eunomia-bpf.github.io/eunomia-bpf/sigsnoop/package.json
```
will work, and be identicital to `ecli run https://eunomia-bpf.github.io/eunomia-bpf/sigsnoop/package.json` now