### PR TITLE
Skip check gitee.com in documents CI

### DIFF
--- a/documents/book.toml
+++ b/documents/book.toml
@@ -15,4 +15,4 @@ enable = true
 [output.linkcheck]
 follow-web-links = true
 
-exclude = [ 'openai.com', 'geekbang.org', 'aliyun.com', 'oschina.net', 'cloudnative.to', 'cncf.io' ]
+exclude = [ 'openai.com', 'geekbang.org', 'aliyun.com', 'oschina.net', 'cloudnative.to', 'cncf.io', 'gitee.com' ]


### PR DESCRIPTION
This PR skips checking links with domain name `gitee.com`. These links usually respond mdbook with 502, but in fact they can be accessed by browser. 