### PR TITLE
Update README.md with a usable wasm image

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ You can get pre-compiled eBPF programs running from the cloud to the kernel in `
 # download the release from https://github.com/eunomia-bpf/eunomia-bpf/releases/latest/download/ecli
 $ wget https://aka.pw/bpf-ecli -O ecli && chmod +x ./ecli
 $ sudo ./ecli run https://eunomia-bpf.github.io/eunomia-bpf/sigsnoop/package.json # simply run a pre-compiled ebpf code from a url
-$ sudo ./ecli run sigsnoop:latest # run with a name and download the latest version bpf tool from our repo
+$ sudo ./ecli run ghcr.io/eunomia-bpf/execve:latest # run with a name and download the latest version bpf tool from our repo
 ```
 
 ## Build or install the project


### PR DESCRIPTION
In the previous README, there is a line `sudo ./ecli run sigsnoop:latest`. But this reference format is not supported anymore (should be `ghcr.io/eunomia-bpf/sigsnoop:latest`). Besides, the sigsnoop image seems to be invalid and outdated. This PR replaces the line with `ghcr.io/eunomia-bpf/execve:latest`, which is usable.