### PR TITLE
Fix an building issue of arm (#276)

### DIFF
--- a/bpf-loader-rs/Cargo.lock
+++ b/bpf-loader-rs/Cargo.lock
@@ -170,7 +170,7 @@ dependencies = [
 
 [[package]]
 name = "bpf-loader-lib"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "base64 0.21.0",

--- a/bpf-loader-rs/bpf-loader-lib/Cargo.toml
+++ b/bpf-loader-rs/bpf-loader-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bpf-loader-lib"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 license = "MIT"
 description = "A library to load json-described ebpf programs, and automatically poll outputs from the program"

--- a/bpf-loader-rs/bpf-loader-lib/src/skeleton/builder.rs
+++ b/bpf-loader-rs/bpf-loader-lib/src/skeleton/builder.rs
@@ -116,10 +116,10 @@ impl<'a> BpfSkeletonBuilder<'a> {
                 .unwrap()
                 .as_os_str()
                 .as_bytes()
-                .as_ptr() as *const i8;
+                .as_ptr() as *const _;
         } else if let Some(env_btf) = env_btf_file_path.as_ref() {
             // SAFETY: env_btf_file_path will live until this function returns
-            open_bpts.btf_custom_path = env_btf.as_bytes().as_ptr() as *const i8;
+            open_bpts.btf_custom_path = env_btf.as_bytes().as_ptr() as *const _;
         } else if !vmlinux_btf_exists {
             bail!("All ways tried to find vmlinux BTF, but not found. Please provide the vmlinux btf using env `BTF_FILE_PATH`. (Tried parameter `btf_archive_path`, {}, and {})",BTF_PATH_ENV_NAME,VMLINUX_BTF_PATH);
         };

--- a/documents/src/installation/build.md
+++ b/documents/src/installation/build.md
@@ -65,4 +65,5 @@ $ make ecc
 
 
 - You can check the Makefile at project root for more details: [Makefile](https://github.com/eunomia-bpf/eunomia-bpf/blob/master/compiler/Makefile)
-- You may want to refer to our CI for more build info: [ecc.yml](https://github.com/eunomia-bpf/eunomia-bpf/blob/master/.github/workflows/ecc.yml)
+- You may want to refer to our CI for more build info: [ecc.yml](https://github.com/eunomia-bpf/eunomia-bpf/blob/master/.github/workflows/ecc-binary.yml)
+

--- a/ecli/client/Cargo.toml
+++ b/ecli/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ecli-rs"
-version = "0.2.6"
+version = "0.2.7"
 edition = "2021"
 description = "The client cli wrapper of ecli"
 license = "MIT"

--- a/ecli/ecli-lib/Cargo.toml
+++ b/ecli/ecli-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ecli-lib"
-version = "0.2.6"
+version = "0.2.7"
 edition = "2021"
 description = "The core implementation of ecli"
 license = "MIT"
@@ -34,7 +34,7 @@ home = "0.5.4"
 thiserror = "1.0.40"
 bpf-oci = "0.1.0"
 # These deps are only needed when `native-client` feature is enabled
-bpf-loader-lib = { path = "../../bpf-loader-rs/bpf-loader-lib", version = "0.1.3", optional = true }
+bpf-loader-lib = { path = "../../bpf-loader-rs/bpf-loader-lib", version = "0.1.7", optional = true }
 wasm-bpf-rs = { version = "0.3.2", optional = true }
 bpf-compatible-rs = { version = "0.1.0", optional = true }
 

--- a/ecli/server/Cargo.toml
+++ b/ecli/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ecli-server"
-version = "0.2.5"
+version = "0.2.7"
 edition = "2021"
 description = "The server cli wrapper of ecli"
 license = "MIT"


### PR DESCRIPTION
Fixes #276 

Use type deduction to avoid the difference of underlying type of c_char between x86 and arm