### PR TITLE
Lock the version of blazesym

### DIFF
--- a/bpf-loader-rs/Cargo.lock
+++ b/bpf-loader-rs/Cargo.lock
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "bpf-loader-lib"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "base64 0.21.2",

--- a/bpf-loader-rs/bpf-loader-lib/Cargo.toml
+++ b/bpf-loader-rs/bpf-loader-lib/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "bpf-loader-lib"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "MIT"
 description = "A library to load json-described ebpf programs, and automatically poll outputs from the program"
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 anyhow = "1.0.70"
 base64 = "0.21.0"
@@ -27,7 +27,7 @@ serde_with = "2.3.2"
 target-lexicon = "^0.11.2"
 bpf-compatible-rs = "0.1.0"
 perf-event-open-sys = "4.0.0"
-blazesym = "0.2.0-alpha.2"
+blazesym = "= 0.2.0-alpha.2"
 
 [features]
 no-load-bpf-tests = []

--- a/ecli/client/Cargo.toml
+++ b/ecli/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ecli-rs"
-version = "0.2.8"
+version = "0.2.9"
 edition = "2021"
 description = "The client cli wrapper of ecli"
 license = "MIT"

--- a/ecli/ecli-lib/Cargo.toml
+++ b/ecli/ecli-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ecli-lib"
-version = "0.2.8"
+version = "0.2.9"
 edition = "2021"
 description = "The core implementation of ecli"
 license = "MIT"
@@ -34,7 +34,7 @@ home = "0.5.4"
 thiserror = "1.0.40"
 bpf-oci = "0.1.0"
 # These deps are only needed when `native-client` feature is enabled
-bpf-loader-lib = { path = "../../bpf-loader-rs/bpf-loader-lib", version = "0.2.0", optional = true }
+bpf-loader-lib = { path = "../../bpf-loader-rs/bpf-loader-lib", version = "0.2.1", optional = true }
 wasm-bpf-rs = { version = "0.3.2", optional = true }
 bpf-compatible-rs = { version = "0.1.0", optional = true }
 

--- a/ecli/server/Cargo.toml
+++ b/ecli/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ecli-server"
-version = "0.2.8"
+version = "0.2.9"
 edition = "2021"
 description = "The server cli wrapper of ecli"
 license = "MIT"


### PR DESCRIPTION
This PR locks the version of blazesym, to avoid break changes involved by the updating of it