### PR TITLE
Update Makefile to remove libllvm14

### DIFF
--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -118,6 +118,7 @@ endif
 install-deps:
 	sudo apt-get update
 	sudo apt-get -y install clang libelf1 libelf-dev zlib1g-dev cmake clang llvm libclang-13-dev
+	sudo apt remove libllvm14
 
 # delete failed targets
 .DELETE_ON_ERROR:


### PR DESCRIPTION
Fix error on:
```
$ ./ecc minimal.bpf.c --verbose
DEBUG [ecc_rs::bpf_compiler] Compiling..
INFO [ecc_rs::bpf_compiler] Compiling bpf object...
DEBUG [ecc_rs::bpf_compiler] Compiling bpf object: output: "minimal.bpf.o", source: "minimal.bpf.c"
DEBUG [ecc_rs::config] $ clang -v -E - </dev/null 2>&1 | sed -n '/<...> search starts here:/,/End of search list./{ s| \(/.*\)|-idirafter \1|p }'
     
DEBUG [ecc_rs::config] -idirafter /usr/lib/llvm-15/lib/clang/15.0.7/include
-idirafter /usr/local/include
-idirafter /usr/include/x86_64-linux-gnu
-idirafter /usr/include

DEBUG [ecc_rs::bpf_compiler] Sys include: ["-idirafter", "/usr/lib/llvm-15/lib/clang/15.0.7/include", "-idirafter", "/usr/local/include", "-idirafter", "/usr/include/x86_64-linux-gnu", "-idirafter", "/usr/include"]
DEBUG [ecc_rs::helper] Target architecture: x86
DEBUG [ecc_rs::helper] Target architecture: x86
DEBUG [ecc_rs::bpf_compiler] $ "clang" CommandArgs { inner: ["-g", "-O2", "-target", "bpf", "-Wno-unknown-attributes", "-D__TARGET_ARCH_x86", "-idirafter", "/usr/lib/llvm-15/lib/clang/15.0.7/include", "-idirafter", "/usr/local/include", "-idirafter", "/usr/include/x86_64-linux-gnu", "-idirafter", "/usr/include", "-I/tmp/.tmpsUOyel/include", "-I/tmp/.tmpsUOyel/include/vmlinux/x86", "-I/home/yunwei/bpftime-archive", "-c", "minimal.bpf.c", "-o", "minimal.bpf.o"] }
DEBUG [ecc_rs::bpf_compiler] 
DEBUG [ecc_rs::bpf_compiler] $ "llvm-strip" CommandArgs { inner: ["-g", "minimal.bpf.o"] }
DEBUG [ecc_rs::bpf_compiler] 
INFO [ecc_rs::bpf_compiler] $ "/tmp/.tmpsUOyel/bin/bpftool" CommandArgs { inner: ["gen", "skeleton", "minimal.bpf.o", "-j"] }
INFO [ecc_rs::bpf_compiler] 
ERROR [ecc_rs::bpf_compiler] /tmp/.tmpsUOyel/bin/bpftool: error while loading shared libraries: libLLVM-14.so.1: cannot open shared object file: No such file or directory

Error: Failed to compile

Caused by:
    Failed to generate skeleton json(exit code = Some(127))
```