### PR TITLE
Update workflow for ecc

### DIFF
--- a/.github/workflows/ecc-binary.yml
+++ b/.github/workflows/ecc-binary.yml
@@ -152,7 +152,7 @@ jobs:
           cp -r ../assets/bpftool/src/libbpf/include/bpf include/
           cp -r ../assets/vmlinux/ include/
           cp ./include/vmlinux/${{matrix.platform.vmlinux_dir}}/vmlinux.h ./include/vmlinux
-      - name: Build ecc on ${{matrix.plaform.rust_target}}
+      - name: Build ecc on ${{matrix.platform.rust_target}}
         run: |
           rustup target add ${{matrix.platform.rust_target}}
           export ECC_CUSTOM_WORKSPACE_ROOT=$(pwd)/workspace

--- a/.github/workflows/ecc-binary.yml
+++ b/.github/workflows/ecc-binary.yml
@@ -195,7 +195,7 @@ jobs:
           git checkout 0594034
       - name: Build workspace in docker
         uses: tj-actions/docker-run@v2
-        if: !matrix.platform.is_cross
+        if: "!matrix.platform.is_cross"
         with:
           image: ubuntu:22.04
           name: build-workspace
@@ -270,7 +270,7 @@ jobs:
           shell: /bin/bash
       - name: Run ecc-rs and retrive what libraries it loaded
         uses: tj-actions/docker-run@v2
-        if: !matrix.platform.is_cross
+        if: "!matrix.platform.is_cross"
         with: 
           image: ubuntu:22.04
           name: get-libraries

--- a/.github/workflows/ecc-binary.yml
+++ b/.github/workflows/ecc-binary.yml
@@ -237,6 +237,8 @@ jobs:
           name: ecc-${{matrix.platform.name}}
           path: ecc-${{matrix.platform.name}}
       - if: matrix.platform.is_cross
+        # qemu-user doesn't seem to handle statically linked binaries well
+        continue-on-error: true
         name: Test the binary in a new environment (cross)
         uses: uraimo/run-on-arch-action@v2
         with: 

--- a/.github/workflows/ecc-binary.yml
+++ b/.github/workflows/ecc-binary.yml
@@ -152,7 +152,7 @@ jobs:
           cp -r ../assets/bpftool/src/libbpf/include/bpf include/
           cp -r ../assets/vmlinux/ include/
           cp ./include/vmlinux/${{matrix.platform.vmlinux_dir}}/vmlinux.h ./include/vmlinux
-      - name: Build ecc on ${{matrix.platform.rust_target}}
+      - name: Build ecc for ${{matrix.platform.rust_target}}
         run: |
           rustup target add ${{matrix.platform.rust_target}}
           export ECC_CUSTOM_WORKSPACE_ROOT=$(pwd)/workspace

--- a/.github/workflows/ecc-binary.yml
+++ b/.github/workflows/ecc-binary.yml
@@ -244,10 +244,10 @@ jobs:
           distro: ubuntu18.04
           run: |
             apt-get update
-            apt-get install -y clang llvm
+            apt-get install -y clang llvm-9
             cd /data
             chmod +x ecc-${{matrix.platform.name}}
-            ./ecc-${{matrix.platform.name}} .github/assets/simple.bpf.c
+            ./ecc-${{matrix.platform.name}} -l llvm-strip-9 .github/assets/simple.bpf.c
           dockerRunArgs: |
             --volume "${PWD}:/data" --privileged
       - name: Test the binary in a new environment (native)
@@ -257,10 +257,10 @@ jobs:
           image: ubuntu:18.04
           run: |
             apt-get update
-            apt-get install -y clang llvm
+            apt-get install -y clang llvm-9
             cd /data
             chmod +x ecc-${{matrix.platform.name}}
-            ./ecc-${{matrix.platform.name}} .github/assets/simple.bpf.c
+            ./ecc-${{matrix.platform.name}} -l llvm-strip-9 .github/assets/simple.bpf.c
           options: |
             --volume ${{github.workspace}}:/data --privileged
 

--- a/.github/workflows/ecc-binary.yml
+++ b/.github/workflows/ecc-binary.yml
@@ -151,11 +151,13 @@ jobs:
 
   build-ecc-binary:
     strategy:
+      fail-fast: false
       matrix:
         platform:
           - name: aarch64
             vmlinux_dir: arm64
             rust_target: aarch64-unknown-linux-gnu
+            rust_target_upper: AARCH64_UNKNOWN_LINUX_GNU
             appimage_runtime: https://github.com/eunomia-bpf/prepare-cargo-appimage/raw/v6/runtime-aarch64
             is_cross: true
             cross_compiler_package: gcc-aarch64-linux-gnu
@@ -296,11 +298,18 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install libfuse2
-      - name: Clone and install cargo-appimage with aarch64 launcher
+      - name: Clone and install cargo-appimage with ${{matrix.platform.name}} launcher
+        if: matrix.platform.is_cross
         run: |
           git clone https://github.com/eunomia-bpf/cargo-appimage
           cd cargo-appimage
-          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=${{matrix.platform.cross_compiler_executable}} RUSTFLAGS="-C target-feature=+crt-static" cargo build --release --target ${{matrix.platform.rust_target}}
+          CARGO_TARGET_${{matrix.platform.rust_target_upper}}_LINKER=${{matrix.platform.cross_compiler_executable}} RUSTFLAGS="-C target-feature=+crt-static" cargo build --release --target ${{matrix.platform.rust_target}}
+      - name: Clone and install cargo-appimage
+        if: "!matrix.platform.is_cross"
+        run: |
+          git clone https://github.com/eunomia-bpf/cargo-appimage
+          cd cargo-appimage
+          RUSTFLAGS="-C target-feature=+crt-static" cargo build --release --target ${{matrix.platform.rust_target}}
       - name: Compose files and pack them
         run: |
           mkdir appimage-root

--- a/.github/workflows/ecc-binary.yml
+++ b/.github/workflows/ecc-binary.yml
@@ -206,8 +206,8 @@ jobs:
             CFLAGS="-static" make
             cp bpftool /workspace/bin
           options: |
-            --volume "${{github.workspace}}/workspace:/workspace"
-            --volume "${{github.workspace}}/assets:/assets"
+            --volume ${{github.workspace}}/workspace:/workspace
+            --volume ${{github.workspace}}/assets:/assets
       - name: Build workspace in ${{matrix.platform.name}} virtual machine
         uses: uraimo/run-on-arch-action@v2
         if: matrix.platform.is_cross
@@ -282,7 +282,7 @@ jobs:
             chmod +x /data/copy-libs.sh
             /data/copy-libs.sh /data/ecc
           options: |
-            --volume "${{github.workspace}}/data:/data"
+            --volume ${{github.workspace}}/data:/data
       - name: Show what libraries were copied
         run: |
           sudo chmod 777 ./data -R

--- a/.github/workflows/ecc-binary.yml
+++ b/.github/workflows/ecc-binary.yml
@@ -206,8 +206,8 @@ jobs:
             CFLAGS="-static" make
             cp bpftool /workspace/bin
           options: |
-            --volume "${PWD}/workspace:/workspace"
-            --volume "${PWD}/assets:/assets"
+            --volume "${{github.workspace}}/workspace:/workspace"
+            --volume "${{github.workspace}}/assets:/assets"
       - name: Build workspace in ${{matrix.platform.name}} virtual machine
         uses: uraimo/run-on-arch-action@v2
         if: matrix.platform.is_cross
@@ -282,7 +282,7 @@ jobs:
             chmod +x /data/copy-libs.sh
             /data/copy-libs.sh /data/ecc
           options: |
-            --volume "${PWD}/data:/data"
+            --volume "${{github.workspace}}/data:/data"
       - name: Show what libraries were copied
         run: |
           sudo chmod 777 ./data -R

--- a/.github/workflows/ecc-binary.yml
+++ b/.github/workflows/ecc-binary.yml
@@ -233,7 +233,7 @@ jobs:
           cp -r ../assets/bpftool/src/libbpf/include/bpf include/
           cp -r ../assets/vmlinux/ include/
           cp ./include/vmlinux/${{matrix.platform.vmlinux_dir}}/vmlinux.h ./include/vmlinux
-      - name: Cross build ecc (aarch64)
+      - name: Build ecc on ${{matrix.plaform.rust_target}}
         run: |
           rustup target add ${{matrix.platform.rust_target}}
           export ECC_CUSTOM_WORKSPACE_ROOT=$(pwd)/workspace

--- a/.github/workflows/ecc-binary.yml
+++ b/.github/workflows/ecc-binary.yml
@@ -282,9 +282,8 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
             files: |
+              ./results/ecc-x86_64/ecc-x86_64
               ./results/ecc-aarch64/ecc-aarch64
-              ./results/ecc-x86_64/ecc
-              ./results/ecc-x86_64/ecc-x86_64-unknown-linux-gnu-${{ needs.create-release-version.outputs.version }}.tar.gz
             prerelease: false
             tag_name: ${{ needs.create-release-version.outputs.version }}
             generate_release_notes: true

--- a/.github/workflows/ecc-binary.yml
+++ b/.github/workflows/ecc-binary.yml
@@ -65,90 +65,6 @@ jobs:
             const tag = tags.find(tag => tag.commit.sha === context.sha);
             
             return tag ? tag.name : increase_v(latest_release_tag)
-  # build-x86_64:
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       target: [ x86_64-unknown-linux-gnu ]
-  #   needs: create-release-version
-  #   steps:
-  #   - uses: actions/checkout@v3
-  #     with:
-  #       submodules: 'recursive'
-  #   - name: install deps
-  #     run: |
-  #         sudo make -C compiler install-deps
-  #         cargo install clippy-sarif sarif-fmt grcov
-  #         rustup component add llvm-tools-preview
-
-  #   - name: Install Rust toolchain
-  #     uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af #@v1
-  #     with:
-  #       profile: minimal
-  #       toolchain: stable
-  #       components: clippy
-  #       override: true
-
-  #   - name: cache dependencies
-  #     uses: actions/cache@v3
-  #     id: cache
-  #     with:
-  #       path: ${{ github.workspace }}/${{ env.INSTALL_LOCATION }}
-  #       key: ${{ runner.os }}-dependencies
-
-  #   - name: Cache rust
-  #     uses: Swatinem/rust-cache@v2
-  #     with:
-  #       workspaces: |
-  #         compiler/cmd
-  #         ecli
-  #         eunomia-sdks/eunomia-rs
-
-  #   - name: build ecc
-  #     run:  cd compiler && make && make install
-  #   - name: Prepare cargo-appimage
-  #     uses: eunomia-bpf/prepare-cargo-appimage@v5
-  #   - name: Install libfuse
-  #     run: |
-  #       sudo apt-get install -y libfuse2
-  #   - name: Build AppImage
-  #     run: |
-  #         cd compiler/cmd
-  #         CARGO_APPIMAGE_TOOL_BIN=../../appimagetool CARGO_APPIMAGE_RUNTIME_FILE=../../runtime CARGO_APPIMAGE_OUT_FILE=ecc cargo appimage 
-  #   - name: test ecc
-  #     run:  cd compiler && make test
-  #   - name: Upload analysis results to GitHub
-  #     if: github.repository_owner == 'eunomia-bpf'
-  #     uses: github/codeql-action/upload-sarif@v2
-  #     with:
-  #       sarif_file: compiler/cmd/rust-clippy-results.sarif
-  #       wait-for-processing: true
-
-  #   - name: Code coverage using Codecov
-  #     if: github.repository_owner == 'eunomia-bpf'
-  #     run: bash <(curl -s https://codecov.io/bash)
-
-  #   - name: Package
-  #     shell: bash
-  #     run: |
-  #       mkdir release
-  #       cp compiler/cmd/ecc ./release/ecc
-  #       cd release
-  #       tar czvf ./ecc-${{ matrix.target }}-${{ needs.create-release-version.outputs.version }}.tar.gz ecc
-  #   - name: Test cli
-  #     shell: bash
-  #     run: |
-  #       mkdir cli-test
-  #       cd cli-test
-  #       cp ../.github/assets/simple.bpf.c .
-  #       ../release/ecc -h
-  #       ../release/ecc simple.bpf.c
-  #   - name: Upload build result
-  #     uses: actions/upload-artifact@v3
-  #     with:
-  #       name: ecc-x86_64
-  #       path: release/*
-
   build-ecc-binary:
     strategy:
       fail-fast: false
@@ -157,7 +73,7 @@ jobs:
           - name: aarch64
             vmlinux_dir: arm64
             rust_target: aarch64-unknown-linux-gnu
-            rust_target_upper: AARCH64_UNKNOWN_LINUX_GNU
+            linker_specifier: CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
             appimage_runtime: https://github.com/eunomia-bpf/prepare-cargo-appimage/raw/v6/runtime-aarch64
             is_cross: true
             cross_compiler_package: gcc-aarch64-linux-gnu
@@ -165,7 +81,8 @@ jobs:
           - name: x86_64
             vmlinux_dir: x86
             rust_target: x86_64-unknown-linux-gnu
-            appimage_runtime: https://github.com/eunomia-bpf/prepare-cargo-appimage/blob/main/runtime-x86_64
+            linker_specifier: 
+            appimage_runtime: https://github.com/eunomia-bpf/prepare-cargo-appimage/raw/v6/runtime-x86_64
             is_cross: false
     name: Build ecc on ${{matrix.platform.name}}
     runs-on: ubuntu-latest
@@ -299,17 +216,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install libfuse2
       - name: Clone and install cargo-appimage with ${{matrix.platform.name}} launcher
-        if: matrix.platform.is_cross
         run: |
           git clone https://github.com/eunomia-bpf/cargo-appimage
           cd cargo-appimage
-          CARGO_TARGET_${{matrix.platform.rust_target_upper}}_LINKER=${{matrix.platform.cross_compiler_executable}} RUSTFLAGS="-C target-feature=+crt-static" cargo build --release --target ${{matrix.platform.rust_target}}
-      - name: Clone and install cargo-appimage
-        if: "!matrix.platform.is_cross"
-        run: |
-          git clone https://github.com/eunomia-bpf/cargo-appimage
-          cd cargo-appimage
-          RUSTFLAGS="-C target-feature=+crt-static" cargo build --release --target ${{matrix.platform.rust_target}}
+          ${{matrix.platform.linker_specifier}} RUSTFLAGS="-C target-feature=+crt-static" cargo build --release --target ${{matrix.platform.rust_target}}
       - name: Compose files and pack them
         run: |
           mkdir appimage-root
@@ -321,6 +231,33 @@ jobs:
           cp ../cargo-appimage/target/${{matrix.platform.rust_target}}/release/cargo-appimage-runner AppRun
           cp ../.github/scripts/cargo-appimage.desktop .
           ../appimagetool --runtime-file ../runtime . ../ecc-${{matrix.platform.name}}
+      - if: matrix.platform.is_cross
+        name: Test the binary in a new environment (cross)
+        uses: uraimo/run-on-arch-action@v2
+        with: 
+          arch: ${{matrix.platform.name}}
+          distro: ubuntu18.04
+          run: |
+            apt-get update
+            apt-get install -y clang
+            cd /data
+            chmod +x ecc-${{matrix.platform.name}}
+            ./ecc-${{matrix.platform.name}} .github/assets/simple.bpf.c
+          dockerRunArgs: |
+            --volume "${PWD}:/data"
+      - name: Test the binary in a new environment (native)
+        uses: addnab/docker-run-action@v3
+        if: "!matrix.platform.is_cross"
+        with:
+          image: ubuntu:18.04
+          run: |
+            apt-get update
+            apt-get install -y clang
+            cd /data
+            chmod +x ecc-${{matrix.platform.name}}
+            ./ecc-${{matrix.platform.name}} .github/assets/simple.bpf.c
+          options: |
+            --volume ${{github.workspace}}:/data
       - uses: actions/upload-artifact@v3
         name: Upload build result
         with:

--- a/.github/workflows/ecc-binary.yml
+++ b/.github/workflows/ecc-binary.yml
@@ -168,7 +168,7 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v2
-      - name: Run ecc-rs and retrive what libraries it loaded
+      - name: Run ecc-rs and retrive what libraries it loaded (cross)
         uses: uraimo/run-on-arch-action@v2
         if: matrix.platform.is_cross
         with: 
@@ -186,7 +186,7 @@ jobs:
           dockerRunArgs: |
             --volume "${PWD}/data:/data"
           shell: /bin/bash
-      - name: Run ecc-rs and retrive what libraries it loaded
+      - name: Run ecc-rs and retrive what libraries it loaded (native)
         uses: addnab/docker-run-action@v3
         if: "!matrix.platform.is_cross"
         with: 
@@ -244,7 +244,7 @@ jobs:
             chmod +x ecc-${{matrix.platform.name}}
             ./ecc-${{matrix.platform.name}} .github/assets/simple.bpf.c
           dockerRunArgs: |
-            --volume "${PWD}:/data"
+            --volume "${PWD}:/data" --privileged
       - name: Test the binary in a new environment (native)
         uses: addnab/docker-run-action@v3
         if: "!matrix.platform.is_cross"
@@ -257,7 +257,7 @@ jobs:
             chmod +x ecc-${{matrix.platform.name}}
             ./ecc-${{matrix.platform.name}} .github/assets/simple.bpf.c
           options: |
-            --volume ${{github.workspace}}:/data
+            --volume ${{github.workspace}}:/data --privileged
       - uses: actions/upload-artifact@v3
         name: Upload build result
         with:

--- a/.github/workflows/ecc-binary.yml
+++ b/.github/workflows/ecc-binary.yml
@@ -231,6 +231,11 @@ jobs:
           cp ../cargo-appimage/target/${{matrix.platform.rust_target}}/release/cargo-appimage-runner AppRun
           cp ../.github/scripts/cargo-appimage.desktop .
           ../appimagetool --runtime-file ../runtime . ../ecc-${{matrix.platform.name}}
+      - uses: actions/upload-artifact@v3
+        name: Upload build result
+        with:
+          name: ecc-${{matrix.platform.name}}
+          path: ecc-${{matrix.platform.name}}
       - if: matrix.platform.is_cross
         name: Test the binary in a new environment (cross)
         uses: uraimo/run-on-arch-action@v2
@@ -239,7 +244,7 @@ jobs:
           distro: ubuntu18.04
           run: |
             apt-get update
-            apt-get install -y clang
+            apt-get install -y clang llvm
             cd /data
             chmod +x ecc-${{matrix.platform.name}}
             ./ecc-${{matrix.platform.name}} .github/assets/simple.bpf.c
@@ -252,17 +257,13 @@ jobs:
           image: ubuntu:18.04
           run: |
             apt-get update
-            apt-get install -y clang
+            apt-get install -y clang llvm
             cd /data
             chmod +x ecc-${{matrix.platform.name}}
             ./ecc-${{matrix.platform.name}} .github/assets/simple.bpf.c
           options: |
             --volume ${{github.workspace}}:/data --privileged
-      - uses: actions/upload-artifact@v3
-        name: Upload build result
-        with:
-          name: ecc-${{matrix.platform.name}}
-          path: ecc-${{matrix.platform.name}}
+
   release:
     needs: [create-release-version, build-ecc-binary]
     runs-on: ubuntu-latest

--- a/.github/workflows/ecc-binary.yml
+++ b/.github/workflows/ecc-binary.yml
@@ -194,12 +194,11 @@ jobs:
           cd bpftool
           git checkout 0594034
       - name: Build workspace in docker
-        uses: tj-actions/docker-run@v2
+        uses: addnab/docker-run-action@v3
         if: "!matrix.platform.is_cross"
         with:
           image: ubuntu:22.04
-          name: build-workspace
-          args: |
+          run: |
             apt-get update
             apt-get install -y zlib1g-dev libelf-dev gcc make
             cd /workspace && mkdir bin
@@ -269,12 +268,11 @@ jobs:
             --volume "${PWD}/data:/data"
           shell: /bin/bash
       - name: Run ecc-rs and retrive what libraries it loaded
-        uses: tj-actions/docker-run@v2
+        uses: addnab/docker-run-action@v3
         if: "!matrix.platform.is_cross"
         with: 
           image: ubuntu:22.04
-          name: get-libraries
-          args: |
+          run: |
             apt-get update
             apt-get install -y libclang1
             echo "Installation done"

--- a/.github/workflows/ecc-binary.yml
+++ b/.github/workflows/ecc-binary.yml
@@ -65,91 +65,107 @@ jobs:
             const tag = tags.find(tag => tag.commit.sha === context.sha);
             
             return tag ? tag.name : increase_v(latest_release_tag)
-  build-x86_64:
-    runs-on: ubuntu-latest
+  # build-x86_64:
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       target: [ x86_64-unknown-linux-gnu ]
+  #   needs: create-release-version
+  #   steps:
+  #   - uses: actions/checkout@v3
+  #     with:
+  #       submodules: 'recursive'
+  #   - name: install deps
+  #     run: |
+  #         sudo make -C compiler install-deps
+  #         cargo install clippy-sarif sarif-fmt grcov
+  #         rustup component add llvm-tools-preview
+
+  #   - name: Install Rust toolchain
+  #     uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af #@v1
+  #     with:
+  #       profile: minimal
+  #       toolchain: stable
+  #       components: clippy
+  #       override: true
+
+  #   - name: cache dependencies
+  #     uses: actions/cache@v3
+  #     id: cache
+  #     with:
+  #       path: ${{ github.workspace }}/${{ env.INSTALL_LOCATION }}
+  #       key: ${{ runner.os }}-dependencies
+
+  #   - name: Cache rust
+  #     uses: Swatinem/rust-cache@v2
+  #     with:
+  #       workspaces: |
+  #         compiler/cmd
+  #         ecli
+  #         eunomia-sdks/eunomia-rs
+
+  #   - name: build ecc
+  #     run:  cd compiler && make && make install
+  #   - name: Prepare cargo-appimage
+  #     uses: eunomia-bpf/prepare-cargo-appimage@v5
+  #   - name: Install libfuse
+  #     run: |
+  #       sudo apt-get install -y libfuse2
+  #   - name: Build AppImage
+  #     run: |
+  #         cd compiler/cmd
+  #         CARGO_APPIMAGE_TOOL_BIN=../../appimagetool CARGO_APPIMAGE_RUNTIME_FILE=../../runtime CARGO_APPIMAGE_OUT_FILE=ecc cargo appimage 
+  #   - name: test ecc
+  #     run:  cd compiler && make test
+  #   - name: Upload analysis results to GitHub
+  #     if: github.repository_owner == 'eunomia-bpf'
+  #     uses: github/codeql-action/upload-sarif@v2
+  #     with:
+  #       sarif_file: compiler/cmd/rust-clippy-results.sarif
+  #       wait-for-processing: true
+
+  #   - name: Code coverage using Codecov
+  #     if: github.repository_owner == 'eunomia-bpf'
+  #     run: bash <(curl -s https://codecov.io/bash)
+
+  #   - name: Package
+  #     shell: bash
+  #     run: |
+  #       mkdir release
+  #       cp compiler/cmd/ecc ./release/ecc
+  #       cd release
+  #       tar czvf ./ecc-${{ matrix.target }}-${{ needs.create-release-version.outputs.version }}.tar.gz ecc
+  #   - name: Test cli
+  #     shell: bash
+  #     run: |
+  #       mkdir cli-test
+  #       cd cli-test
+  #       cp ../.github/assets/simple.bpf.c .
+  #       ../release/ecc -h
+  #       ../release/ecc simple.bpf.c
+  #   - name: Upload build result
+  #     uses: actions/upload-artifact@v3
+  #     with:
+  #       name: ecc-x86_64
+  #       path: release/*
+
+  build-ecc-binary:
     strategy:
       matrix:
-        target: [ x86_64-unknown-linux-gnu ]
-    needs: create-release-version
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: 'recursive'
-    - name: install deps
-      run: |
-          sudo make -C compiler install-deps
-          cargo install clippy-sarif sarif-fmt grcov
-          rustup component add llvm-tools-preview
-
-    - name: Install Rust toolchain
-      uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af #@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        components: clippy
-        override: true
-
-    - name: cache dependencies
-      uses: actions/cache@v3
-      id: cache
-      with:
-        path: ${{ github.workspace }}/${{ env.INSTALL_LOCATION }}
-        key: ${{ runner.os }}-dependencies
-
-    - name: Cache rust
-      uses: Swatinem/rust-cache@v2
-      with:
-        workspaces: |
-          compiler/cmd
-          ecli
-          eunomia-sdks/eunomia-rs
-
-    - name: build ecc
-      run:  cd compiler && make && make install
-    - name: Prepare cargo-appimage
-      uses: eunomia-bpf/prepare-cargo-appimage@v5
-    - name: Install libfuse
-      run: |
-        sudo apt-get install -y libfuse2
-    - name: Build AppImage
-      run: |
-          cd compiler/cmd
-          CARGO_APPIMAGE_TOOL_BIN=../../appimagetool CARGO_APPIMAGE_RUNTIME_FILE=../../runtime CARGO_APPIMAGE_OUT_FILE=ecc cargo appimage 
-    - name: test ecc
-      run:  cd compiler && make test
-    - name: Upload analysis results to GitHub
-      if: github.repository_owner == 'eunomia-bpf'
-      uses: github/codeql-action/upload-sarif@v2
-      with:
-        sarif_file: compiler/cmd/rust-clippy-results.sarif
-        wait-for-processing: true
-
-    - name: Code coverage using Codecov
-      if: github.repository_owner == 'eunomia-bpf'
-      run: bash <(curl -s https://codecov.io/bash)
-
-    - name: Package
-      shell: bash
-      run: |
-        mkdir release
-        cp compiler/cmd/ecc ./release/ecc
-        cd release
-        tar czvf ./ecc-${{ matrix.target }}-${{ needs.create-release-version.outputs.version }}.tar.gz ecc
-    - name: Test cli
-      shell: bash
-      run: |
-        mkdir cli-test
-        cd cli-test
-        cp ../.github/assets/simple.bpf.c .
-        ../release/ecc -h
-        ../release/ecc simple.bpf.c
-    - name: Upload build result
-      uses: actions/upload-artifact@v3
-      with:
-        name: ecc-x86_64
-        path: release/*
-
-  build-aarch64:
+        platform:
+          - name: aarch64
+            vmlinux_dir: arm64
+            rust_target: aarch64-unknown-linux-gnu
+            appimage_runtime: https://github.com/eunomia-bpf/prepare-cargo-appimage/raw/v6/runtime-aarch64
+            is_cross: true
+            cross_compiler_package: gcc-aarch64-linux-gnu
+            cross_compiler_executable: aarch64-linux-gnu-gcc
+          - name: x86_64
+            vmlinux_dir: x86
+            rust_target: x86_64-unknown-linux-gnu
+            appimage_runtime: https://github.com/eunomia-bpf/prepare-cargo-appimage/blob/main/runtime-x86_64
+            is_cross: false
+    name: Build ecc on ${{matrix.platform.name}}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -157,11 +173,11 @@ jobs:
         with:
           submodules: 'recursive'
       - name: Install dependencies for cross building
+        if: matrix.platform.is_cross
         run: |
           sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu
-          ls /usr/lib/gcc-cross/aarch64-linux-gnu/
-          aarch64-linux-gnu-gcc --version
+          sudo apt-get install -y ${{matrix.platform.cross_compiler_package}}
+          ${{matrix.platform.cross_compiler_executable}} --version
       - name: Prepare bpftool and vmlinux repo for building workspace
         # Move more steps outside of the virtual machine
         run: |
@@ -177,10 +193,27 @@ jobs:
           git clone --recursive https://github.com/eunomia-bpf/bpftool
           cd bpftool
           git checkout 0594034
-      - name: Build workspace in aarch64 virtual machine
+      - name: Build workspace in docker
+        uses: tj-actions/docker-run@v2
+        if: !matrix.platform.is_cross
+        with:
+          image: ubuntu:22.04
+          name: build-workspace
+          args: |
+            apt-get update
+            apt-get install -y zlib1g-dev libelf-dev gcc make
+            cd /workspace && mkdir bin
+            cd /assets/bpftool/src
+            CFLAGS="-static" make
+            cp bpftool /workspace/bin
+          options: |
+            --volume "${PWD}/workspace:/workspace"
+            --volume "${PWD}/assets:/assets"
+      - name: Build workspace in ${{matrix.platform.name}} virtual machine
         uses: uraimo/run-on-arch-action@v2
+        if: matrix.platform.is_cross
         with: 
-          arch: aarch64
+          arch: ${{matrix.platform.name}}
           distro: ubuntu22.04
           run: |
             apt-get update
@@ -200,17 +233,17 @@ jobs:
           mkdir include
           cp -r ../assets/bpftool/src/libbpf/include/bpf include/
           cp -r ../assets/vmlinux/ include/
-          cp ./include/vmlinux/arm64/vmlinux.h ./include/vmlinux
+          cp ./include/vmlinux/${{matrix.platform.vmlinux_dir}}/vmlinux.h ./include/vmlinux
       - name: Cross build ecc (aarch64)
         run: |
-          rustup target add aarch64-unknown-linux-gnu
+          rustup target add ${{matrix.platform.rust_target}}
           export ECC_CUSTOM_WORKSPACE_ROOT=$(pwd)/workspace
           echo "Workspace dir: $ECC_CUSTOM_WORKSPACE_ROOT"
           cd compiler/cmd
-          cargo build --release --target aarch64-unknown-linux-gnu
+          cargo build --release --target ${{matrix.platform.rust_target}}
           cd ../..
           mkdir data
-          cp ./compiler/cmd/target/aarch64-unknown-linux-gnu/release/ecc-rs data/ecc
+          cp ./compiler/cmd/target/${{matrix.platform.rust_target}}/release/ecc-rs data/ecc
           cp ./.github/scripts/copy-libs.sh ./data
           ls -lah data
       # Necessary if we want to run things cross platform
@@ -219,8 +252,9 @@ jobs:
         uses: docker/setup-buildx-action@v2
       - name: Run ecc-rs and retrive what libraries it loaded
         uses: uraimo/run-on-arch-action@v2
+        if: matrix.platform.is_cross
         with: 
-          arch: aarch64
+          arch: ${{matrix.platform.name}}
           distro: ubuntu22.04
           run: |
             apt-get update
@@ -234,6 +268,23 @@ jobs:
           dockerRunArgs: |
             --volume "${PWD}/data:/data"
           shell: /bin/bash
+      - name: Run ecc-rs and retrive what libraries it loaded
+        uses: tj-actions/docker-run@v2
+        if: !matrix.platform.is_cross
+        with: 
+          image: ubuntu:22.04
+          name: get-libraries
+          args: |
+            apt-get update
+            apt-get install -y libclang1
+            echo "Installation done"
+            echo "Working directory $(pwd)"
+            chmod +x /data/ecc
+            echo "Permission set done"
+            chmod +x /data/copy-libs.sh
+            /data/copy-libs.sh /data/ecc
+          options: |
+            --volume "${PWD}/data:/data"
       - name: Show what libraries were copied
         run: |
           sudo chmod 777 ./data -R
@@ -242,7 +293,7 @@ jobs:
       - name: Prepare runtime file and cargo-appimage tool
         uses: eunomia-bpf/prepare-cargo-appimage@v6
         with: 
-          runtime-url: https://github.com/eunomia-bpf/prepare-cargo-appimage/raw/v6/runtime-aarch64
+          runtime-url: ${{matrix.platform.appimage_runtime}}
       - name: Install libfuse for appimagetool
         run: |
           sudo apt-get update
@@ -251,7 +302,7 @@ jobs:
         run: |
           git clone https://github.com/eunomia-bpf/cargo-appimage
           cd cargo-appimage
-          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc RUSTFLAGS="-C target-feature=+crt-static" cargo build --release --target aarch64-unknown-linux-gnu
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=${{matrix.platform.cross_compiler_executable}} RUSTFLAGS="-C target-feature=+crt-static" cargo build --release --target ${{matrix.platform.rust_target}}
       - name: Compose files and pack them
         run: |
           mkdir appimage-root
@@ -260,16 +311,16 @@ jobs:
           mkdir -p usr/bin
           cp ../data/ecc usr/bin/bin
           touch icon.png
-          cp ../cargo-appimage/target/aarch64-unknown-linux-gnu/release/cargo-appimage-runner AppRun
+          cp ../cargo-appimage/target/${{matrix.platform.rust_target}}/release/cargo-appimage-runner AppRun
           cp ../.github/scripts/cargo-appimage.desktop .
-          ../appimagetool --runtime-file ../runtime . ../ecc-aarch64
+          ../appimagetool --runtime-file ../runtime . ../ecc-${{matrix.platform.name}}
       - uses: actions/upload-artifact@v3
         name: Upload build result
         with:
-          name: ecc-aarch64
-          path: ecc-aarch64
+          name: ecc-${{matrix.platform.name}}
+          path: ecc-${{matrix.platform.name}}
   release:
-    needs: [create-release-version, build-aarch64, build-x86_64]
+    needs: [create-release-version, build-ecc-binary]
     runs-on: ubuntu-latest
     steps:
       - name: Download build results

--- a/compiler/cmd/Cargo.lock
+++ b/compiler/cmd/Cargo.lock
@@ -416,6 +416,7 @@ dependencies = [
  "serde_yaml",
  "tar",
  "tempfile",
+ "walkdir",
 ]
 
 [[package]]

--- a/compiler/cmd/Cargo.lock
+++ b/compiler/cmd/Cargo.lock
@@ -395,7 +395,7 @@ checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
 
 [[package]]
 name = "ecc-rs"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "base64",

--- a/compiler/cmd/Cargo.toml
+++ b/compiler/cmd/Cargo.toml
@@ -26,6 +26,7 @@ log = "0.4.17"
 flexi_logger = "0.25.4"
 anyhow = { version = "1.0.71", features = ["backtrace"] }
 clang-sys = { version = "1.4.0", features = ["runtime"] }
+walkdir = "2.3.3"
 
 # [target.'cfg(target_arch = "aarch64")'.dependencies.clang-sys]
 # version = "1.4.0"

--- a/compiler/cmd/Cargo.toml
+++ b/compiler/cmd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ecc-rs"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 license = "MIT"
 description = "A compiler to produce ebpf programs that can be run by ecli"
@@ -25,14 +25,13 @@ clap = { version = "4.2.7", features = ["derive"] }
 log = "0.4.17"
 flexi_logger = "0.25.4"
 anyhow = { version = "1.0.71", features = ["backtrace"] }
+clang-sys = { version = "1.4.0", features = ["runtime"] }
 
-[target.'cfg(target_arch = "aarch64")'.dependencies.clang-sys]
-version = "1.4.0"
-features = ["runtime"]
-
-[target.'cfg(not(target_arch = "aarch64"))'.dependencies.clang-sys]
-version = "1.4.0"
-
+# [target.'cfg(target_arch = "aarch64")'.dependencies.clang-sys]
+# version = "1.4.0"
+# features = ["runtime"]
+# [target.'cfg(not(target_arch = "aarch64"))'.dependencies.clang-sys]
+# version = "1.4.0"
 [build-dependencies]
 anyhow = "1.0.71"
 dircpy = "0.3.14"

--- a/compiler/cmd/build.rs
+++ b/compiler/cmd/build.rs
@@ -79,6 +79,7 @@ fn fetch_git_repo(url: &str, git_ref: &str, local_dir: &Path) -> anyhow::Result<
 fn fetch_and_build_bpftool() -> anyhow::Result<()> {
     fetch_git_repo(&bpftool_repo(), &bpftool_ref(), &bpftool_repodir())?;
     if !Command::new("make")
+        .arg("-j")
         .current_dir(workdir().join(bpftool_repodir()).join("src"))
         .status()?
         .success()

--- a/compiler/cmd/src/main.rs
+++ b/compiler/cmd/src/main.rs
@@ -13,16 +13,45 @@ mod wasm;
 #[cfg(test)]
 pub(crate) mod tests;
 
+use std::{path::PathBuf, str::FromStr};
+
 use anyhow::Result;
 use bpf_compiler::*;
 use clap::Parser;
 use config::{CompileArgs, EunomiaWorkspace};
+use log::warn;
+use walkdir::WalkDir;
 
 fn main() -> Result<()> {
     use anyhow::anyhow;
+    // Searches for the libclang in the appimage runner-defined paths, if applies
+    if let Ok(v) = std::env::var("EUNOMIA_APPIMAGE_DEFINED_LD_LIBRARY_PATH") {
+        let mut libclang_path = None;
+        for dir in v.split(':') {
+            let dir = PathBuf::from_str(dir)?;
+            if dir.exists() {
+                for entry in WalkDir::new(dir).into_iter() {
+                    let entry = entry?;
+                    if entry.file_type().is_file()
+                        && entry.file_name().to_string_lossy().starts_with("libclang")
+                    {
+                        libclang_path =
+                            Some(entry.path().parent().unwrap().to_string_lossy().to_string());
+                    }
+                }
+            }
+        }
+        if let Some(v) = libclang_path {
+            std::env::set_var("LIBCLANG_PATH", v);
+        } else {
+            warn!("libclang not found in EUNOMIA_APPIMAGE_DEFINED_LD_LIBRARY_PATH. Caution for library version issues.");
+        }
+    }
     clang_sys::load()
         .map_err(|e| anyhow!("Failed to load libclang dynamically at runtime: {}", e))?;
+
     let args = CompileArgs::parse();
+
     flexi_logger::Logger::try_with_env_or_str(if args.verbose { "debug" } else { "info" })?
         .start()?;
     let workspace = EunomiaWorkspace::init(args)?;

--- a/compiler/cmd/src/main.rs
+++ b/compiler/cmd/src/main.rs
@@ -19,12 +19,9 @@ use clap::Parser;
 use config::{CompileArgs, EunomiaWorkspace};
 
 fn main() -> Result<()> {
-    #[cfg(target_arch = "aarch64")]
-    {
-        use anyhow::anyhow;
-        clang_sys::load()
-            .map_err(|e| anyhow!("Failed to load libclang dynamically at runtime: {}", e))?;
-    }
+    use anyhow::anyhow;
+    clang_sys::load()
+        .map_err(|e| anyhow!("Failed to load libclang dynamically at runtime: {}", e))?;
     let args = CompileArgs::parse();
     flexi_logger::Logger::try_with_env_or_str(if args.verbose { "debug" } else { "info" })?
         .start()?;


### PR DESCRIPTION
This PR updates the workflow to release ecc binaries, merging steps to build ecc on various archs, and ships the statically linked embedded bpftool.

- Support for more archs could be added once type2 runtime of appimage could run on it. 