### PR TITLE
Fix CI issue of  https://github.com/eunomia-bpf/eunomia-bpf/actions/runs/6025105527/job/16345133074

### DIFF
--- a/.github/workflows/ecc-image-x86_64.yml
+++ b/.github/workflows/ecc-image-x86_64.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Test the docker image (x86_64)
         run: |
           sudo apt-get update
-          sudo apt-get remove moby-containerd moby-runc 
+          sudo apt-get remove moby-containerd moby-runc containerd.io
           sudo apt-get install -y docker.io
           mkdir docker-test
           cd docker-test


### PR DESCRIPTION
The action `docker/setup-buildx-action@v2` will install a package named `containerd`, which conflicts with `containerd.io`, while the second one is depended by `docker.io`. We need `docker.io` from apt to run image tests, so this pr uninstalls `containerd.io` before installing `docker.io` through apt, and fixes the issue