### PR TITLE
Add build from source wiki Link to README.md [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ For more information, see [documents/src/ecli/server.md](documents/src/ecli/serv
 
 - build the compiler, runtime library and tools:
 
-  see [build](documents/src/miscellaneous/build.md) for building details.
+  see [build](https://eunomia.dev/setup/build) for building details.
 
 ## Examples
 


### PR DESCRIPTION
## Description
Old `build` link point to none.Fix it to link to correct pages.
For developers to build more convenient.

## Type of change
Please delete options that are not relevant.

- [x] This change requires a documentation update