### PR TITLE
Default use os-native data dir path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,9 +52,12 @@ eunomia-exporter: ## build the exporter for custom metric
 	make -C bpf-loader-rs
 	cd eunomia-exporter && cargo build --release
 
+XDG_DATA_HOME ?= ${HOME}/.local/share
+EUNOMIA_HOME := $(XDG_DATA_HOME)/eunomia
+
 release:
 	make -C ecli install
 	make -C compiler install
-	cp -R ~/.eunomia .eunomia
-	tar -czvf eunomia.tar.gz .eunomia
-	rm -rf .eunomia
+	cp -R $(EUNOMIA_HOME) eunomia
+	tar -czvf eunomia.tar.gz eunomia
+	rm -rf eunomia

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -69,9 +69,11 @@ $(ECC): $(BPFTOOL)
 	cd cmd && cp -r `cargo out-dir`/workspace ..
 	cp $(ECC) workspace/bin/ecc-rs
 
-install:
-	rm -rf ~/.eunomia && cp -r workspace ~/.eunomia
+XDG_DATA_HOME ?= ${HOME}/.local/share
+EUNOMIA_HOME := $(XDG_DATA_HOME)/eunomia
 
+install:
+	rm -rf $(EUNOMIA_HOME) && cp -r workspace $(EUNOMIA_HOME)
 .PHONY: test
 test:
 	cargo install clippy-sarif sarif-fmt grcov
@@ -97,7 +99,7 @@ test:
 
 .PHONY: build
 build-ebpf-program:
-	$(Q)~/.eunomia/bin/ecc-rs $(shell ls $(SOURCE_DIR)*.bpf.c) $(shell ls -h1 $(SOURCE_DIR)*.h | grep -v .*\.bpf\.h)
+	$(Q)$(EUNOMIA_HOME)/bin/ecc-rs $(shell ls $(SOURCE_DIR)*.bpf.c) $(shell ls -h1 $(SOURCE_DIR)*.h | grep -v .*\.bpf\.h)
 
 .PHONY: docker
 docker: wasi-sdk-16.0-linux.tar.gz

--- a/compiler/README.md
+++ b/compiler/README.md
@@ -40,7 +40,6 @@ Makefile build the toolchain:
 git submodule update --init --recursive --remote       # check out libbpf
 make
 make install
-export PATH=$PATH:~/.eunomia/bin
 ```
 
 After the toolchain has been build, run:

--- a/documents/src/ecli/index.md
+++ b/documents/src/ecli/index.md
@@ -41,4 +41,4 @@ For details, see [ecc-btfgen](../ecc/usage.md#options)
     `ecli` will check [gh](https://cli.github.com/) cache and `GITHUB_TOKEN`
     env when you login to ghcr.io, either one can be logged into ghcr without entering a token.
 - logout - Logout from an OCI registry.
-    `ecli logout xxx` will remove identity certificates stored under `~/.eunomia`.
+    `ecli logout xxx` will remove identity certificates stored under data dir, generally located at `~/.local/share/eunomia`.

--- a/ecli/Cargo.toml
+++ b/ecli/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-
+resolver = "2"
 members = [
     "ecli-lib",
     "client",

--- a/ecli/Makefile
+++ b/ecli/Makefile
@@ -1,3 +1,5 @@
+XDG_DATA_HOME ?= ${HOME}/.local/share
+EUNOMIA_HOME := $(XDG_DATA_HOME)/eunomia
 
 .PHONY: build
 build:
@@ -6,9 +8,9 @@ build:
 install:
 	rm -rf target/
 	cargo build --release
-	rm -rf ~/.eunomia
-	mkdir -p ~/.eunomia/bin
-	cp ./target/release/ecli-rs ~/.eunomia/bin/ecli
+	rm -rf $(EUNOMIA_HOME)
+	mkdir -p $(EUNOMIA_HOME)/bin
+	cp ./target/release/ecli-rs $(EUNOMIA_HOME)/bin/ecli
 
 install-deps:
 	sudo apt install libssl-dev

--- a/ecli/ecli-lib/src/helper.rs
+++ b/ecli/ecli-lib/src/helper.rs
@@ -1,21 +1,40 @@
 use crate::error::{Error, Result};
+use std::env::var;
+use std::path::PathBuf;
 
 const EUNOMIA_HOME_ENV: &str = "EUNOMIA_HOME";
 
 /// Get eunomia home directory
 pub fn get_eunomia_home() -> Result<String> {
-    let eunomia_home = std::env::var(EUNOMIA_HOME_ENV);
-    if let Ok(home) = eunomia_home {
-        Ok(home)
-    } else if let Some(home) = home::home_dir() {
-        let home = home.join(".eunomia");
-        if !home.exists() {
-            std::fs::create_dir_all(&home).map_err(Error::IOErr)?;
-        }
-        Ok(home.to_string_lossy().to_string())
+    if let Ok(e) = var(EUNOMIA_HOME_ENV) {
+        return Ok(e.into());
+    };
+
+    // search from xdg standard directory
+    let eunomia_home_search_path: Vec<PathBuf> = if let Ok(e) = var("XDG_DATA_HOME") {
+        e.split(':')
+            .map(|s| PathBuf::from(format!("{s}/eunomia")))
+            .collect()
     } else {
-        Err(Error::Other(
-            "home dir not found. Please set EUNOMIA_HOME env.".to_string(),
+        if let Ok(e) = var("HOME") {
+            let home_dir = PathBuf::from(e);
+            let eunomia_home = home_dir.join(".local/share/eunomia");
+
+            if home_dir.exists() {
+                if !eunomia_home.exists() {
+                    std::fs::create_dir_all(&eunomia_home).map_err(Error::IOErr)?
+                }
+                return Ok(eunomia_home.to_string_lossy().to_string());
+            }
+        }
+        Vec::new()
+    };
+
+    return eunomia_home_search_path
+        .into_iter()
+        .find(|p| p.exists())
+        .ok_or(Error::Other(
+            "eunomia data home not found, try setting `EUNOMIA_HOME`".to_string(),
         ))
-    }
+        .map(|p| p.to_string_lossy().to_string());
 }


### PR DESCRIPTION
## Summary
Resolve #310 

For `ecc` and `ecli`, search data dir follow the sequence of `$EUNOMIA_HOME`, `$XDG_DATA_HOME/eunomia`, `$HOME/.local/share/eunomia`.
 `$XDG_DATA_HOME` is where user-specific data files should be written according to [specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).