### PR TITLE
ci: fix docker image ci

### DIFF
--- a/.github/assets/simple.h
+++ b/.github/assets/simple.h
@@ -1,0 +1,5 @@
+#ifndef _SIMPLE_H
+#define _SIMPLE_H
+
+
+#endif

--- a/.github/workflows/ecc-image-x86_64.yml
+++ b/.github/workflows/ecc-image-x86_64.yml
@@ -55,6 +55,7 @@ jobs:
           mkdir docker-test
           cd docker-test
           cp ../.github/assets/simple.bpf.c .
+          cp ../.github/assets/simple.h .
           docker run -v `pwd`/:/src/ ghcr.io/${{ env.REPO_OWNER }}/ecc-x86_64:latest
           if [[ ! -f "./package.json" ]]
           then

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -73,7 +73,7 @@ XDG_DATA_HOME ?= ${HOME}/.local/share
 EUNOMIA_HOME := $(XDG_DATA_HOME)/eunomia
 
 install:
-	rm -rf $(EUNOMIA_HOME) && mkdir -p $(EUNOMIA_HOME) && cp -r workspace $(EUNOMIA_HOME)
+	rm -rf $(EUNOMIA_HOME) && mkdir -p $(EUNOMIA_HOME) && cp -r workspace/* $(EUNOMIA_HOME)
 .PHONY: test
 test:
 	cargo install clippy-sarif sarif-fmt grcov


### PR DESCRIPTION
workflows to publish & test docker image have been down for a long time, this PR fixes them.

The rootcause is an incorrect path in `ecc/Makefile`