### PR TITLE
cmd: fixed unused `Result`

### DIFF
--- a/compiler/cmd/src/helper.rs
+++ b/compiler/cmd/src/helper.rs
@@ -31,7 +31,7 @@ pub fn get_eunomia_data_dir() -> Result<PathBuf> {
                             "Unable to create data directory for eunomia: {}",
                             eunomia_home.to_string_lossy()
                         )
-                    });
+                    })?;
                 }
                 return Ok(eunomia_home);
             }


### PR DESCRIPTION
Fixed the unused `Result` that must be used warning.

```shell
eunomia-bpf/compiler/cmd# cargo check
    Checking ecc-rs v0.3.4 (/root/TEMP/eunomia-bpf/compiler/cmd)
warning: unused `Result` that must be used
  --> src/helper.rs:29:21
   |
29 | /                     std::fs::create_dir_all(&eunomia_home).with_context(|| {
30 | |                         anyhow!(
31 | |                             "Unable to create data directory for eunomia: {}",
32 | |                             eunomia_home.to_string_lossy()
33 | |                         )
34 | |                     });
   | |______________________^
   |
   = note: this `Result` may be an `Err` variant, which should be handled
   = note: `#[warn(unused_must_use)]` on by default
help: use `let _ = ...` to ignore the resulting value
   |
29 |                     let _ = std::fs::create_dir_all(&eunomia_home).with_context(|| {
   |                     +++++++

warning: `ecc-rs` (bin "ecc-rs") generated 1 warning
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.21s
```
