### PR TITLE
bpf-loader-rs: fixed build warning

### DIFF
--- a/bpf-loader-rs/bpf-loader-lib/src/skeleton/preload/attach/mod.rs
+++ b/bpf-loader-rs/bpf-loader-lib/src/skeleton/preload/attach/mod.rs
@@ -30,7 +30,7 @@ pub(crate) enum AttachLink {
 impl Drop for AttachLink {
     fn drop(&mut self) {
         match self {
-            AttachLink::BpfLink(_) => {}
+            AttachLink::BpfLink(_link) => {}
             AttachLink::TCAttach(hook) => {
                 let err = unsafe { bpf_tc_hook_destroy(&mut **hook) };
                 if err != 0 {
@@ -43,7 +43,7 @@ impl Drop for AttachLink {
                     error!("Failed to detach xdp: \n{:?}", err);
                 }
             }
-            AttachLink::PerfEventAttachWithFd(_, fd) => {
+            AttachLink::PerfEventAttachWithFd(_link, fd) => {
                 debug!("Closing pefd {}", fd);
                 // SAFETY: fds are created by us, they are gurateended to be correct
                 let _ = unsafe { fd::OwnedFd::from_raw_fd(*fd as _) };


### PR DESCRIPTION
```shell
$ cargo build
warning: field `0` is never read
  --> bpf-loader-lib/src/skeleton/preload/attach/mod.rs:24:13
   |
24 |     BpfLink(Link),
   |     ------- ^^^^
   |     |
   |     field in this variant
   |
   = note: `#[warn(dead_code)]` on by default
help: consider changing the field to be of unit type to suppress this warning while preserving the field numbering, or remove the field
   |
24 |     BpfLink(()),
   |             ~~

warning: field `0` is never read
  --> bpf-loader-lib/src/skeleton/preload/attach/mod.rs:27:27
   |
27 |     PerfEventAttachWithFd(Link, i32),
   |     --------------------- ^^^^
   |     |
   |     field in this variant
   |
help: consider changing the field to be of unit type to suppress this warning while preserving the field numbering, or remove the field
   |
27 |     PerfEventAttachWithFd((), i32),
   |                           ~~

warning: `bpf-loader-lib` (lib) generated 2 warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.15s
```