### PR TITLE
ci: normalize SPDX header spaces

### DIFF
--- a/.github/scripts/check-spdx-header-space.sh
+++ b/.github/scripts/check-spdx-header-space.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+matches="$(git grep -n $'\u00a0SPDX-License-Identifier:' -- bpf-loader-rs compiler ecli eunomia-sdks || true)"
+
+if [[ -n "$matches" ]]; then
+  echo "Found non-breaking spaces in SPDX headers:"
+  echo "$matches"
+  exit 1
+fi

--- a/.github/workflows/c-cpp-lint.yml
+++ b/.github/workflows/c-cpp-lint.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    - name: Check SPDX headers use ASCII spaces
+      run: ./.github/scripts/check-spdx-header-space.sh
     - uses: DoozyX/clang-format-lint-action@v0.14
       with:
         source: 'examples'

--- a/compiler/cmd/build.rs
+++ b/compiler/cmd/build.rs
@@ -1,4 +1,4 @@
-//!  SPDX-License-Identifier: MIT
+//!  SPDX-License-Identifier: MIT
 //!
 //! Copyright (c) 2023, eunomia-bpf
 //! All rights reserved.

--- a/compiler/cmd/src/bpf_compiler/mod.rs
+++ b/compiler/cmd/src/bpf_compiler/mod.rs
@@ -1,4 +1,4 @@
-//!  SPDX-License-Identifier: MIT
+//!  SPDX-License-Identifier: MIT
 //!
 //! Copyright (c) 2023, eunomia-bpf
 //! All rights reserved.

--- a/compiler/cmd/src/bpf_compiler/standalone.rs
+++ b/compiler/cmd/src/bpf_compiler/standalone.rs
@@ -1,4 +1,4 @@
-//!  SPDX-License-Identifier: MIT
+//!  SPDX-License-Identifier: MIT
 //!
 //! Copyright (c) 2023, eunomia-bpf
 //! All rights reserved.

--- a/compiler/cmd/src/bpf_compiler/tests.rs
+++ b/compiler/cmd/src/bpf_compiler/tests.rs
@@ -1,4 +1,4 @@
-//!  SPDX-License-Identifier: MIT
+//!  SPDX-License-Identifier: MIT
 //!
 //! Copyright (c) 2023, eunomia-bpf
 //! All rights reserved.

--- a/compiler/cmd/src/config/mod.rs
+++ b/compiler/cmd/src/config/mod.rs
@@ -1,4 +1,4 @@
-//!  SPDX-License-Identifier: MIT
+//!  SPDX-License-Identifier: MIT
 //!
 //! Copyright (c) 2023, eunomia-bpf
 //! All rights reserved.

--- a/compiler/cmd/src/config/options.rs
+++ b/compiler/cmd/src/config/options.rs
@@ -1,4 +1,4 @@
-//!  SPDX-License-Identifier: MIT
+//!  SPDX-License-Identifier: MIT
 //!
 //! Copyright (c) 2023, eunomia-bpf
 //! All rights reserved.

--- a/compiler/cmd/src/config/tests.rs
+++ b/compiler/cmd/src/config/tests.rs
@@ -1,4 +1,4 @@
-//!  SPDX-License-Identifier: MIT
+//!  SPDX-License-Identifier: MIT
 //!
 //! Copyright (c) 2023, eunomia-bpf
 //! All rights reserved.

--- a/compiler/cmd/src/document_parser.rs
+++ b/compiler/cmd/src/document_parser.rs
@@ -1,4 +1,4 @@
-//!  SPDX-License-Identifier: MIT
+//!  SPDX-License-Identifier: MIT
 //!
 //! Copyright (c) 2023, eunomia-bpf
 //! All rights reserved.

--- a/compiler/cmd/src/export_types.rs
+++ b/compiler/cmd/src/export_types.rs
@@ -1,4 +1,4 @@
-//!  SPDX-License-Identifier: MIT
+//!  SPDX-License-Identifier: MIT
 //!
 //! Copyright (c) 2023, eunomia-bpf
 //! All rights reserved.

--- a/compiler/cmd/src/helper.rs
+++ b/compiler/cmd/src/helper.rs
@@ -1,4 +1,4 @@
-//!  SPDX-License-Identifier: MIT
+//!  SPDX-License-Identifier: MIT
 //!
 //! Copyright (c) 2023, eunomia-bpf
 //! All rights reserved.

--- a/compiler/cmd/src/main.rs
+++ b/compiler/cmd/src/main.rs
@@ -1,4 +1,4 @@
-//!  SPDX-License-Identifier: MIT
+//!  SPDX-License-Identifier: MIT
 //!
 //! Copyright (c) 2023, eunomia-bpf
 //! All rights reserved.

--- a/compiler/cmd/src/tests.rs
+++ b/compiler/cmd/src/tests.rs
@@ -1,4 +1,4 @@
-//!  SPDX-License-Identifier: MIT
+//!  SPDX-License-Identifier: MIT
 //!
 //! Copyright (c) 2023, eunomia-bpf
 //! All rights reserved.

--- a/ecli/client/src/helper.rs
+++ b/ecli/client/src/helper.rs
@@ -1,4 +1,4 @@
-//!  SPDX-License-Identifier: MIT
+//!  SPDX-License-Identifier: MIT
 //!
 //! Copyright (c) 2023, eunomia-bpf
 //! All rights reserved.

--- a/ecli/client/src/http_client.rs
+++ b/ecli/client/src/http_client.rs
@@ -1,4 +1,4 @@
-//!  SPDX-License-Identifier: MIT
+//!  SPDX-License-Identifier: MIT
 //!
 //! Copyright (c) 2023, eunomia-bpf
 //! All rights reserved.

--- a/ecli/client/src/native_client.rs
+++ b/ecli/client/src/native_client.rs
@@ -1,4 +1,4 @@
-//!  SPDX-License-Identifier: MIT
+//!  SPDX-License-Identifier: MIT
 //!
 //! Copyright (c) 2023, eunomia-bpf
 //! All rights reserved.

--- a/ecli/ecli-lib/src/config/mod.rs
+++ b/ecli/ecli-lib/src/config/mod.rs
@@ -1,4 +1,4 @@
-//!  SPDX-License-Identifier: MIT
+//!  SPDX-License-Identifier: MIT
 //!
 //! Copyright (c) 2023, eunomia-bpf
 //! All rights reserved.

--- a/ecli/ecli-lib/src/error.rs
+++ b/ecli/ecli-lib/src/error.rs
@@ -1,4 +1,4 @@
-//!  SPDX-License-Identifier: MIT
+//!  SPDX-License-Identifier: MIT
 //!
 //! Copyright (c) 2023, eunomia-bpf
 //! All rights reserved.

--- a/ecli/ecli-lib/src/lib.rs
+++ b/ecli/ecli-lib/src/lib.rs
@@ -1,4 +1,4 @@
-//!  SPDX-License-Identifier: MIT
+//!  SPDX-License-Identifier: MIT
 //!
 //! Copyright (c) 2023, eunomia-bpf
 //! All rights reserved.

--- a/ecli/ecli-lib/src/runner/client/http.rs
+++ b/ecli/ecli-lib/src/runner/client/http.rs
@@ -1,4 +1,4 @@
-//!  SPDX-License-Identifier: MIT
+//!  SPDX-License-Identifier: MIT
 //!
 //! Copyright (c) 2023, eunomia-bpf
 //! All rights reserved.

--- a/ecli/ecli-lib/src/runner/client/mod.rs
+++ b/ecli/ecli-lib/src/runner/client/mod.rs
@@ -1,4 +1,4 @@
-//!  SPDX-License-Identifier: MIT
+//!  SPDX-License-Identifier: MIT
 //!
 //! Copyright (c) 2023, eunomia-bpf
 //! All rights reserved.

--- a/ecli/ecli-lib/src/runner/client/native.rs
+++ b/ecli/ecli-lib/src/runner/client/native.rs
@@ -1,4 +1,4 @@
-//!  SPDX-License-Identifier: MIT
+//!  SPDX-License-Identifier: MIT
 //!
 //! Copyright (c) 2023, eunomia-bpf
 //! All rights reserved.

--- a/ecli/ecli-lib/src/runner/helper.rs
+++ b/ecli/ecli-lib/src/runner/helper.rs
@@ -1,4 +1,4 @@
-//!  SPDX-License-Identifier: MIT
+//!  SPDX-License-Identifier: MIT
 //!
 //! Copyright (c) 2023, eunomia-bpf
 //! All rights reserved.

--- a/ecli/ecli-lib/src/runner/mod.rs
+++ b/ecli/ecli-lib/src/runner/mod.rs
@@ -1,4 +1,4 @@
-//!  SPDX-License-Identifier: MIT
+//!  SPDX-License-Identifier: MIT
 //!
 //! Copyright (c) 2023, eunomia-bpf
 //! All rights reserved.

--- a/ecli/ecli-lib/src/runner/server_http/mod.rs
+++ b/ecli/ecli-lib/src/runner/server_http/mod.rs
@@ -1,4 +1,4 @@
-//!  SPDX-License-Identifier: MIT
+//!  SPDX-License-Identifier: MIT
 //!
 //! Copyright (c) 2023, eunomia-bpf
 //! All rights reserved.

--- a/ecli/ecli-lib/src/runner/task_manager/mod.rs
+++ b/ecli/ecli-lib/src/runner/task_manager/mod.rs
@@ -1,4 +1,4 @@
-//!  SPDX-License-Identifier: MIT
+//!  SPDX-License-Identifier: MIT
 //!
 //! Copyright (c) 2023, eunomia-bpf
 //! All rights reserved.

--- a/ecli/ecli-lib/tests/api_test.rs
+++ b/ecli/ecli-lib/tests/api_test.rs
@@ -1,4 +1,4 @@
-//!  SPDX-License-Identifier: MIT
+//!  SPDX-License-Identifier: MIT
 //!
 //! Copyright (c) 2023, eunomia-bpf
 //! All rights reserved.

--- a/ecli/server/src/main.rs
+++ b/ecli/server/src/main.rs
@@ -1,4 +1,4 @@
-//!  SPDX-License-Identifier: MIT
+//!  SPDX-License-Identifier: MIT
 //!
 //! Copyright (c) 2023, eunomia-bpf
 //! All rights reserved.

--- a/eunomia-sdks/eunomia-otel/build.rs
+++ b/eunomia-sdks/eunomia-otel/build.rs
@@ -1,4 +1,4 @@
-//!  SPDX-License-Identifier: MIT
+//!  SPDX-License-Identifier: MIT
 //!
 //! Copyright (c) 2023, eunomia-bpf
 //! All rights reserved.

--- a/eunomia-sdks/eunomia-otel/src/bindings.rs
+++ b/eunomia-sdks/eunomia-otel/src/bindings.rs
@@ -3,7 +3,7 @@
 //! develop an approach to compile, transmit, and run most
 //! libbpf CO-RE objects with some user space config meta
 //! data to help us load and operator the eBPF byte code.
-//!  SPDX-License-Identifier: MIT
+//!  SPDX-License-Identifier: MIT
 //!
 //! Copyright (c) 2023, eunomia-bpf
 //! All rights reserved.

--- a/eunomia-sdks/eunomia-otel/src/bpfmanager.rs
+++ b/eunomia-sdks/eunomia-otel/src/bpfmanager.rs
@@ -1,4 +1,4 @@
-//!  SPDX-License-Identifier: MIT
+//!  SPDX-License-Identifier: MIT
 //!
 //! Copyright (c) 2023, eunomia-bpf
 //! All rights reserved.

--- a/eunomia-sdks/eunomia-otel/src/bpfprog.rs
+++ b/eunomia-sdks/eunomia-otel/src/bpfprog.rs
@@ -1,4 +1,4 @@
-//!  SPDX-License-Identifier: MIT
+//!  SPDX-License-Identifier: MIT
 //!
 //! Copyright (c) 2023, eunomia-bpf
 //! All rights reserved.

--- a/eunomia-sdks/eunomia-otel/src/config.rs
+++ b/eunomia-sdks/eunomia-otel/src/config.rs
@@ -1,4 +1,4 @@
-//!  SPDX-License-Identifier: MIT
+//!  SPDX-License-Identifier: MIT
 //!
 //! Copyright (c) 2023, eunomia-bpf
 //! All rights reserved.

--- a/eunomia-sdks/eunomia-otel/src/main.rs
+++ b/eunomia-sdks/eunomia-otel/src/main.rs
@@ -1,4 +1,4 @@
-//!  SPDX-License-Identifier: MIT
+//!  SPDX-License-Identifier: MIT
 //!
 //! Copyright (c) 2023, eunomia-bpf
 //! All rights reserved.

--- a/eunomia-sdks/eunomia-otel/src/server.rs
+++ b/eunomia-sdks/eunomia-otel/src/server.rs
@@ -1,4 +1,4 @@
-//!  SPDX-License-Identifier: MIT
+//!  SPDX-License-Identifier: MIT
 //!
 //! Copyright (c) 2023, eunomia-bpf
 //! All rights reserved.

--- a/eunomia-sdks/eunomia-otel/src/state.rs
+++ b/eunomia-sdks/eunomia-otel/src/state.rs
@@ -1,4 +1,4 @@
-//!  SPDX-License-Identifier: MIT
+//!  SPDX-License-Identifier: MIT
 //!
 //! Copyright (c) 2023, eunomia-bpf
 //! All rights reserved.

--- a/eunomia-sdks/eunomia-rs/src/lib.rs
+++ b/eunomia-sdks/eunomia-rs/src/lib.rs
@@ -1,4 +1,4 @@
-//!  SPDX-License-Identifier: MIT
+//!  SPDX-License-Identifier: MIT
 //!
 //! Copyright (c) 2023, eunomia-bpf
 //! All rights reserved.


### PR DESCRIPTION
Fixes #349

## Summary
- replace non-breaking spaces in SPDX headers with ASCII spaces
- add a lightweight CI check to prevent NBSP from reappearing in SPDX headers

## Testing
- ./.github/scripts/check-spdx-header-space.sh
- bash -n .github/scripts/check-spdx-header-space.sh
- git diff --check