### PR TITLE
ecli: remove dead server config flag

### DIFF
--- a/ecli/server/README.md
+++ b/ecli/server/README.md
@@ -1,19 +1,17 @@
-# eserver
+# ecli-server
 
 ## Start
 ```console
-$ sudo ./eserver
+$ sudo ./ecli-server
 Server start at 127.0.0.1:8527
 ```
 
 ```console
-$ ./eserver --help
-Usage: eserver [OPTIONS]
+$ ./ecli-server --help
+Usage: ecli-server [OPTIONS]
 
 Options:
-  -c, --config <CONFIG>  
-  -s, --secure           
-  -p, --port <PORT>      server port [default: 8527]
-  -a, --addr <ADDR>      [default: 127.0.0.1]
+  -p, --port <PORT>      Port to bind [default: 8527]
+  -a, --addr <ADDR>      Address to bind [default: 127.0.0.1]
   -h, --help             Print help
 ```

--- a/ecli/server/src/main.rs
+++ b/ecli/server/src/main.rs
@@ -21,8 +21,6 @@ use ecli_lib::{
 
 #[derive(Parser)]
 struct Args {
-    #[arg(short, long)]
-    config: Option<String>,
     #[clap(short, long, help = "Port to bind", default_value = "8527")]
     port: u16,
     #[arg(short, long, default_value = "127.0.0.1", help = "Address to bind")]

--- a/ecli/tests/api-test.py
+++ b/ecli/tests/api-test.py
@@ -19,7 +19,7 @@ def run(cmd):
 if __name__ == "__main__":
     log_level = "RUST_LOG=info "
     cli_bin = ["ecli/target/release/ecli-rs"]
-    server_bin = ["ecli/target/release/eserver"]
+    server_bin = ["ecli/target/release/ecli-server"]
     env_dbg = os.environ.copy()
     env_dbg["RUST_LOG"] = "info"
     example_path = "examples/bpftools/"


### PR DESCRIPTION
## Summary\n- remove the unused \'--config\' option from ecli-server\n- update the server README to match the current CLI\n- fix the legacy API test script to use the current ecli-server binary name\n\n## Verification\n- cargo run --manifest-path ecli/server/Cargo.toml -- --help\n- cargo build --manifest-path ecli/server/Cargo.toml --release\n- ecli/target/release/ecli-server --help\n- python3 -m py_compile ecli/tests/api-test.py\n- git diff --check