### PR TITLE
ci: dedupe heavy workflow triggers

### DIFF
--- a/.github/workflows/ecc-binary.yml
+++ b/.github/workflows/ecc-binary.yml
@@ -3,7 +3,8 @@ name: Build and release standalone binary of ecc
 on:
     workflow_dispatch: 
     push:
-      branches: ["*"]
+      branches:
+        - master
       paths:
         - "ecli/**"
         - "compiler/**"  # Ensure ecc and ecli releasing at same time

--- a/.github/workflows/ecli-binary.yaml
+++ b/.github/workflows/ecli-binary.yaml
@@ -3,7 +3,9 @@ name: Build and test and publish ecli binary (multiple platforms and archs)
 on:
   workflow_dispatch: 
   push:
-    branches: ["*"]
+    branches:
+      - master
+      - "fix*"
     paths:
       - "ecli/**"
       - "compiler/**"  # Ensure ecc and ecli releasing at same time

--- a/.github/workflows/eunomia-bpf.yml
+++ b/.github/workflows/eunomia-bpf.yml
@@ -2,7 +2,8 @@ name: Build and test bpf-loader-rs on Ubuntu
 
 on:
   push:
-    branches: "*"
+    branches:
+      - master
   pull_request:
     branches: "*"
 env:
@@ -44,4 +45,3 @@ jobs:
 
     - name: Code coverage using Codecov
       run: bash <(curl -s https://codecov.io/bash)
-

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,6 +1,8 @@
 name: "Nix build check"
 on:
   push:
+    branches:
+      - master
   pull_request:
 
 jobs:


### PR DESCRIPTION
## Summary
- restrict heavy workflow `push` triggers to `master`
- keep `pull_request` validation so PRs still get coverage
- preserve the existing `fix*` push path in `ecli` workflow

## Testing
- git diff --check
- python3 workflow YAML parse check
