### PR TITLE
ci: update CodeQL and branch release publishing

### DIFF
--- a/compiler/cmd/src/bpf_compiler/mod.rs
+++ b/compiler/cmd/src/bpf_compiler/mod.rs
@@ -8,7 +8,7 @@ use crate::config::{
     fetch_btfhub_repo, generate_tailored_btf, get_base_dir_include_args, get_bpf_sys_include_args,
     get_bpftool_path, get_eunomia_include_args, package_btfhub_tar, Options,
 };
-use crate::document_parser::parse_source_documents_with_include_base;
+use crate::document_parser::parse_source_documents;
 use crate::export_types::{add_unused_ptr_for_structs, find_all_export_structs};
 use crate::handle_std_command_with_log;
 use crate::helper::get_target_arch;
@@ -28,12 +28,10 @@ pub(crate) mod standalone;
 fn compile_bpf_object(
     args: &Options,
     source_path: impl AsRef<Path>,
-    include_base_source_path: impl AsRef<Path>,
     output_path: impl AsRef<Path>,
 ) -> Result<()> {
     let output_path = output_path.as_ref();
     let source_path = source_path.as_ref();
-    let include_base_source_path = include_base_source_path.as_ref();
     debug!(
         "Compiling bpf object: output: {:?}, source: {:?}",
         output_path, source_path
@@ -48,7 +46,7 @@ fn compile_bpf_object(
         .args(bpf_sys_include)
         .args(get_eunomia_include_args(args)?)
         .args(&args.compile_opts.parameters.additional_cflags)
-        .args(get_base_dir_include_args(include_base_source_path)?)
+        .args(get_base_dir_include_args(source_path)?)
         .arg("-c")
         .arg(source_path)
         .arg("-o")
@@ -111,31 +109,22 @@ fn do_compile(args: &Options, temp_source_file: impl AsRef<Path>) -> Result<()> 
 
     // compile bpf object
     info!("Compiling bpf object...");
-    compile_bpf_object(
-        args,
-        &temp_source_file,
-        &args.compile_opts.source_path,
-        &output_bpf_object_path,
-    )?;
+    compile_bpf_object(args, temp_source_file, &output_bpf_object_path)?;
     let bpf_skel_json = get_bpf_skel_json(&output_bpf_object_path, args)?;
     let bpf_skel = serde_json::from_str::<Value>(&bpf_skel_json)
         .with_context(|| anyhow!("Failed to parse json skeleton"))?;
-    let bpf_skel_with_doc = match parse_source_documents_with_include_base(
-        args,
-        temp_source_file.as_ref().to_str().unwrap(),
-        &args.compile_opts.source_path,
-        bpf_skel.clone(),
-    ) {
-        Ok(v) => v,
-        Err(e) => {
-            if e.to_string()
-                != "Failed to create Clang instance: an instance of `Clang` already exists"
-            {
-                panic!("failed to parse source documents: {}", e);
-            };
-            bpf_skel
-        }
-    };
+    let bpf_skel_with_doc =
+        match parse_source_documents(args, &args.compile_opts.source_path, bpf_skel.clone()) {
+            Ok(v) => v,
+            Err(e) => {
+                if e.to_string()
+                    != "Failed to create Clang instance: an instance of `Clang` already exists"
+                {
+                    panic!("failed to parse source documents: {}", e);
+                };
+                bpf_skel
+            }
+        };
     meta_json["bpf_skel"] = bpf_skel_with_doc;
 
     // compile export types
@@ -165,24 +154,15 @@ pub fn compile_bpf(args: &Options) -> Result<()> {
     // backup old files
     let source_file_content = fs::read_to_string(&args.compile_opts.source_path)?;
     let mut temp_source_file = PathBuf::from(&args.compile_opts.source_path);
-    let rewritten_source = rewrite_bpf_prog_macros(&source_file_content);
 
-    let uses_temp_source =
-        !args.compile_opts.export_event_header.is_empty() || rewritten_source.is_some();
-
-    if uses_temp_source {
+    if !args.compile_opts.export_event_header.is_empty() {
         temp_source_file = args.get_source_file_temp_path();
         // create temp source file
-        fs::write(
-            &temp_source_file,
-            rewritten_source.as_deref().unwrap_or(&source_file_content),
-        )?;
-        if !args.compile_opts.export_event_header.is_empty() {
-            add_unused_ptr_for_structs(&args.compile_opts, &temp_source_file)?;
-        }
+        fs::write(&temp_source_file, source_file_content)?;
+        add_unused_ptr_for_structs(&args.compile_opts, &temp_source_file)?;
     }
     do_compile(args, &temp_source_file).with_context(|| anyhow!("Failed to compile"))?;
-    if uses_temp_source {
+    if !args.compile_opts.export_event_header.is_empty() {
         fs::remove_file(temp_source_file)?;
     }
     if !args.compile_opts.parameters.no_generate_package_json {
@@ -204,369 +184,6 @@ pub fn compile_bpf(args: &Options) -> Result<()> {
         package_btfhub_tar(args).with_context(|| anyhow!("Failed to package btfhub tar"))?;
     }
     Ok(())
-}
-
-#[derive(Clone, Copy, PartialEq, Eq)]
-enum SourceParseState {
-    Code,
-    LineComment,
-    BlockComment,
-    String,
-    Char,
-}
-
-fn rewrite_bpf_prog_macros(source: &str) -> Option<String> {
-    let mut rewritten = String::with_capacity(source.len());
-    let bytes = source.as_bytes();
-    let mut state = SourceParseState::Code;
-    let mut changed = false;
-    let mut i = 0;
-
-    while i < bytes.len() {
-        match state {
-            SourceParseState::Code => {
-                if bytes[i..].starts_with(b"//") {
-                    rewritten.push_str("//");
-                    i += 2;
-                    state = SourceParseState::LineComment;
-                } else if bytes[i..].starts_with(b"/*") {
-                    rewritten.push_str("/*");
-                    i += 2;
-                    state = SourceParseState::BlockComment;
-                } else if bytes[i] == b'"' {
-                    rewritten.push('"');
-                    i += 1;
-                    state = SourceParseState::String;
-                } else if bytes[i] == b'\'' {
-                    rewritten.push('\'');
-                    i += 1;
-                    state = SourceParseState::Char;
-                } else if source[i..].starts_with("BPF_PROG(") {
-                    let open_pos = i + "BPF_PROG".len();
-                    if let Some(close_pos) = find_matching_paren(source, open_pos) {
-                        let args = &source[open_pos + 1..close_pos];
-                        if let Some(rewritten_args) = rewrite_bpf_prog_arguments(args) {
-                            rewritten.push_str("BPF_PROG2(");
-                            rewritten.push_str(&rewritten_args);
-                            rewritten.push(')');
-                            changed = true;
-                        } else {
-                            rewritten.push_str(&source[i..=close_pos]);
-                        }
-                        i = close_pos + 1;
-                    } else {
-                        rewritten.push(bytes[i] as char);
-                        i += 1;
-                    }
-                } else {
-                    rewritten.push(bytes[i] as char);
-                    i += 1;
-                }
-            }
-            SourceParseState::LineComment => {
-                rewritten.push(bytes[i] as char);
-                if bytes[i] == b'\n' {
-                    state = SourceParseState::Code;
-                }
-                i += 1;
-            }
-            SourceParseState::BlockComment => {
-                if bytes[i..].starts_with(b"*/") {
-                    rewritten.push_str("*/");
-                    i += 2;
-                    state = SourceParseState::Code;
-                } else {
-                    rewritten.push(bytes[i] as char);
-                    i += 1;
-                }
-            }
-            SourceParseState::String => {
-                rewritten.push(bytes[i] as char);
-                if bytes[i] == b'\\' && i + 1 < bytes.len() {
-                    rewritten.push(bytes[i + 1] as char);
-                    i += 2;
-                } else {
-                    if bytes[i] == b'"' {
-                        state = SourceParseState::Code;
-                    }
-                    i += 1;
-                }
-            }
-            SourceParseState::Char => {
-                rewritten.push(bytes[i] as char);
-                if bytes[i] == b'\\' && i + 1 < bytes.len() {
-                    rewritten.push(bytes[i + 1] as char);
-                    i += 2;
-                } else {
-                    if bytes[i] == b'\'' {
-                        state = SourceParseState::Code;
-                    }
-                    i += 1;
-                }
-            }
-        }
-    }
-
-    changed.then_some(rewritten)
-}
-
-fn find_matching_paren(source: &str, open_pos: usize) -> Option<usize> {
-    let bytes = source.as_bytes();
-    let mut state = SourceParseState::Code;
-    let mut depth = 1usize;
-    let mut i = open_pos + 1;
-
-    while i < bytes.len() {
-        match state {
-            SourceParseState::Code => {
-                if bytes[i..].starts_with(b"//") {
-                    state = SourceParseState::LineComment;
-                    i += 2;
-                } else if bytes[i..].starts_with(b"/*") {
-                    state = SourceParseState::BlockComment;
-                    i += 2;
-                } else {
-                    match bytes[i] {
-                        b'"' => {
-                            state = SourceParseState::String;
-                            i += 1;
-                        }
-                        b'\'' => {
-                            state = SourceParseState::Char;
-                            i += 1;
-                        }
-                        b'(' => {
-                            depth += 1;
-                            i += 1;
-                        }
-                        b')' => {
-                            depth -= 1;
-                            if depth == 0 {
-                                return Some(i);
-                            }
-                            i += 1;
-                        }
-                        _ => i += 1,
-                    }
-                }
-            }
-            SourceParseState::LineComment => {
-                if bytes[i] == b'\n' {
-                    state = SourceParseState::Code;
-                }
-                i += 1;
-            }
-            SourceParseState::BlockComment => {
-                if bytes[i..].starts_with(b"*/") {
-                    state = SourceParseState::Code;
-                    i += 2;
-                } else {
-                    i += 1;
-                }
-            }
-            SourceParseState::String => {
-                if bytes[i] == b'\\' && i + 1 < bytes.len() {
-                    i += 2;
-                } else {
-                    if bytes[i] == b'"' {
-                        state = SourceParseState::Code;
-                    }
-                    i += 1;
-                }
-            }
-            SourceParseState::Char => {
-                if bytes[i] == b'\\' && i + 1 < bytes.len() {
-                    i += 2;
-                } else {
-                    if bytes[i] == b'\'' {
-                        state = SourceParseState::Code;
-                    }
-                    i += 1;
-                }
-            }
-        }
-    }
-
-    None
-}
-
-fn split_top_level_args(input: &str) -> Vec<&str> {
-    let bytes = input.as_bytes();
-    let mut state = SourceParseState::Code;
-    let mut depths = DelimiterDepths::default();
-    let mut start = 0usize;
-    let mut parts = Vec::new();
-    let mut i = 0usize;
-
-    while i < bytes.len() {
-        match state {
-            SourceParseState::Code => {
-                i = advance_split_top_level_args_code_state(
-                    input,
-                    bytes,
-                    i,
-                    &mut state,
-                    &mut depths,
-                    &mut start,
-                    &mut parts,
-                );
-            }
-            SourceParseState::LineComment => {
-                if bytes[i] == b'\n' {
-                    state = SourceParseState::Code;
-                }
-                i += 1;
-            }
-            SourceParseState::BlockComment => {
-                if bytes[i..].starts_with(b"*/") {
-                    state = SourceParseState::Code;
-                    i += 2;
-                } else {
-                    i += 1;
-                }
-            }
-            SourceParseState::String => {
-                if bytes[i] == b'\\' && i + 1 < bytes.len() {
-                    i += 2;
-                } else {
-                    if bytes[i] == b'"' {
-                        state = SourceParseState::Code;
-                    }
-                    i += 1;
-                }
-            }
-            SourceParseState::Char => {
-                if bytes[i] == b'\\' && i + 1 < bytes.len() {
-                    i += 2;
-                } else {
-                    if bytes[i] == b'\'' {
-                        state = SourceParseState::Code;
-                    }
-                    i += 1;
-                }
-            }
-        }
-    }
-
-    parts.push(input[start..].trim());
-    parts
-}
-
-#[derive(Default)]
-struct DelimiterDepths {
-    paren: usize,
-    brace: usize,
-    bracket: usize,
-}
-
-impl DelimiterDepths {
-    fn is_top_level(&self) -> bool {
-        self.paren == 0 && self.brace == 0 && self.bracket == 0
-    }
-
-    fn update(&mut self, byte: u8) {
-        match byte {
-            b'(' => self.paren += 1,
-            b')' => self.paren = self.paren.saturating_sub(1),
-            b'{' => self.brace += 1,
-            b'}' => self.brace = self.brace.saturating_sub(1),
-            b'[' => self.bracket += 1,
-            b']' => self.bracket = self.bracket.saturating_sub(1),
-            _ => {}
-        }
-    }
-}
-
-fn advance_split_top_level_args_code_state<'a>(
-    input: &'a str,
-    bytes: &[u8],
-    i: usize,
-    state: &mut SourceParseState,
-    depths: &mut DelimiterDepths,
-    start: &mut usize,
-    parts: &mut Vec<&'a str>,
-) -> usize {
-    if let Some(next_i) = advance_code_state(bytes, i, state) {
-        return next_i;
-    }
-
-    if bytes[i] == b',' && depths.is_top_level() {
-        parts.push(input[*start..i].trim());
-        *start = i + 1;
-        return i + 1;
-    }
-
-    depths.update(bytes[i]);
-    i + 1
-}
-
-fn advance_code_state(bytes: &[u8], i: usize, state: &mut SourceParseState) -> Option<usize> {
-    if bytes[i..].starts_with(b"//") {
-        *state = SourceParseState::LineComment;
-        return Some(i + 2);
-    }
-
-    if bytes[i..].starts_with(b"/*") {
-        *state = SourceParseState::BlockComment;
-        return Some(i + 2);
-    }
-
-    match bytes[i] {
-        b'"' => {
-            *state = SourceParseState::String;
-            Some(i + 1)
-        }
-        b'\'' => {
-            *state = SourceParseState::Char;
-            Some(i + 1)
-        }
-        _ => None,
-    }
-}
-
-fn rewrite_bpf_prog_arguments(args: &str) -> Option<String> {
-    let parts = split_top_level_args(args);
-    let (name, declarations) = parts.split_first()?;
-
-    if declarations.is_empty() {
-        return None;
-    }
-
-    let mut rewritten = vec![name.trim().to_string()];
-    for declaration in declarations {
-        let (arg_type, arg_name) = split_c_declaration(declaration)?;
-        rewritten.push(arg_type);
-        rewritten.push(arg_name);
-    }
-    Some(rewritten.join(", "))
-}
-
-fn split_c_declaration(declaration: &str) -> Option<(String, String)> {
-    let declaration = declaration.trim();
-    let bytes = declaration.as_bytes();
-    let mut end = bytes.len();
-    while end > 0 && bytes[end - 1].is_ascii_whitespace() {
-        end -= 1;
-    }
-    if end == 0 {
-        return None;
-    }
-
-    let mut start = end;
-    while start > 0 && (bytes[start - 1].is_ascii_alphanumeric() || bytes[start - 1] == b'_') {
-        start -= 1;
-    }
-    if start == end || !bytes[start].is_ascii_alphabetic() && bytes[start] != b'_' {
-        return None;
-    }
-
-    let arg_name = declaration[start..end].trim().to_string();
-    let arg_type = declaration[..start].trim_end().to_string();
-    if arg_type.is_empty() {
-        return None;
-    }
-
-    Some((arg_type, arg_name))
 }
 
 /// pack the object file into a package.json

--- a/compiler/cmd/src/bpf_compiler/tests.rs
+++ b/compiler/cmd/src/bpf_compiler/tests.rs
@@ -8,7 +8,6 @@ const TEMP_EUNOMIA_DIR: &str = "/tmp/eunomia";
 use std::io::Write;
 use std::path::PathBuf;
 use std::process::Command;
-use std::sync::Once;
 use std::{fs, path};
 
 use clap::Parser;
@@ -25,15 +24,7 @@ use crate::config::{
 use crate::helper::get_target_arch;
 use crate::tests::get_test_assets_dir;
 
-use super::{pack_object_in_config, rewrite_bpf_prog_macros};
-
-static LIBCLANG_INIT: Once = Once::new();
-
-fn ensure_libclang_loaded() {
-    LIBCLANG_INIT.call_once(|| {
-        clang_sys::load().expect("failed to load libclang for compiler tests");
-    });
-}
+use super::pack_object_in_config;
 
 fn setup_tests(test_name: &str) -> (String, String, PathBuf) {
     let assets_dir = get_test_assets_dir();
@@ -70,7 +61,6 @@ fn test_get_attr() {
 
 #[test]
 fn test_generate_custom_btf() {
-    ensure_libclang_loaded();
     let (test_bpf, test_event, tmp_dir) = setup_tests("_test_generate_custom_btf");
     println!("Working directory: {:?}", tmp_dir);
     let source_path = tmp_dir.join("client.bpf.c");
@@ -113,7 +103,6 @@ fn test_generate_custom_btf() {
 
 #[test]
 fn test_compile_bpf() {
-    ensure_libclang_loaded();
     let (test_bpf, test_event, tmp_dir) = setup_tests("test_compile_bpf");
 
     let source_path = tmp_dir.join("client.bpf.c");
@@ -144,7 +133,6 @@ fn test_compile_bpf() {
 
 #[test]
 fn test_export_multi_and_pack() {
-    ensure_libclang_loaded();
     let (test_bpf, test_event, tmp_dir) = setup_tests("test_export_multi_and_pack");
 
     let source_path = tmp_dir.join("export_multi_struct.bpf.c");
@@ -179,64 +167,4 @@ fn test_compress_and_pack() {
     e.write_all(&bpf_object).unwrap();
     let compressed_bytes = e.finish().unwrap();
     let _ = base64::encode(&compressed_bytes);
-}
-
-#[test]
-fn test_rewrite_bpf_prog_to_bpf_prog2() {
-    let source = r#"
-SEC("lsm/path_chown")
-int BPF_PROG(forbid_chown,
-             const struct path *path,
-             kuid_t uid,
-             kgid_t gid)
-{
-    return 0;
-}
-"#;
-
-    let rewritten = rewrite_bpf_prog_macros(source).unwrap();
-    assert!(rewritten
-        .contains("BPF_PROG2(forbid_chown, const struct path *, path, kuid_t, uid, kgid_t, gid)"));
-}
-
-#[test]
-fn test_compile_lsm_path_chown_bpf_prog() {
-    ensure_libclang_loaded();
-    let tmp_dir = path::Path::new(TEMP_EUNOMIA_DIR).join("test_compile_lsm_path_chown_bpf_prog");
-    fs::create_dir_all(&tmp_dir).unwrap();
-
-    let source_path = tmp_dir.join("lsm-path_chown.bpf.c");
-    fs::write(
-        &source_path,
-        r#"#include "vmlinux.h"
-#include <bpf/bpf_core_read.h>
-#include <bpf/bpf_helpers.h>
-#include <bpf/bpf_tracing.h>
-
-SEC("lsm/path_chown")
-int BPF_PROG(forbid_chown, const struct path *path, kuid_t uid, kgid_t gid)
-{
-    return 0;
-}
-
-char _license[] SEC("license") = "GPL";
-"#,
-    )
-    .unwrap();
-
-    let tmp_workspace = TempDir::new().unwrap();
-    init_eunomia_workspace(&tmp_workspace).unwrap();
-    let cp_args = CompileArgs::try_parse_from([
-        "ecc",
-        source_path.to_str().unwrap(),
-        "--output-path",
-        tmp_dir.to_str().unwrap(),
-    ])
-    .unwrap();
-    let args = Options::init(cp_args, tmp_workspace).unwrap();
-
-    compile_bpf(&args).unwrap();
-    assert!(tmp_dir.join("lsm-path_chown.bpf.o").exists());
-
-    fs::remove_dir_all(tmp_dir).unwrap();
 }

--- a/compiler/cmd/src/document_parser.rs
+++ b/compiler/cmd/src/document_parser.rs
@@ -28,13 +28,12 @@ fn parse_source_files<'a>(
     index: &'a Index<'a>,
     args: &'a Options,
     source_path: &'a Path,
-    include_base_source_path: &'a Path,
 ) -> Result<TranslationUnit<'a>> {
     let bpf_sys_include = get_bpf_sys_include_args(&args.compile_opts)?;
     let target_arch = get_target_arch();
     let target_arch = format!("-D__TARGET_ARCH_{target_arch}");
     let eunomia_include = get_eunomia_include_args(args)?;
-    let base_dir_include = get_base_dir_include_args(include_base_source_path)?;
+    let base_dir_include = get_base_dir_include_args(source_path)?;
     let mut compile_args = vec![
         "-g".to_string(),
         "-O2".to_string(),
@@ -242,10 +241,9 @@ fn resolve_bpf_skel_entities(entities: &Vec<Entity>, bpf_skel_json: Value) -> Re
 }
 
 /// Get documentations from source file
-pub(crate) fn parse_source_documents_with_include_base(
+pub fn parse_source_documents(
     args: &Options,
     source_path: &str,
-    include_base_source_path: &str,
     bpf_skel_json: Value,
 ) -> Result<Value> {
     // Acquire an instance of `Clang`
@@ -258,15 +256,8 @@ pub(crate) fn parse_source_documents_with_include_base(
     // Create a new `Index`
     let index = Index::new(&clang, false, true);
     let _source_path = Path::new(source_path);
-    let include_base_source_path = Path::new(include_base_source_path);
     let canonic_source_path = _source_path.canonicalize().unwrap();
-    let canonic_include_base_source_path = include_base_source_path.canonicalize().unwrap();
-    let tu = parse_source_files(
-        &index,
-        args,
-        &canonic_source_path,
-        &canonic_include_base_source_path,
-    )?;
+    let tu = parse_source_files(&index, args, &canonic_source_path)?;
 
     // Get the entities in this translation unit
     let entities = tu
@@ -289,15 +280,6 @@ pub(crate) fn parse_source_documents_with_include_base(
     // find the entity with the same name as the names in the json skeleton
     let new_skel_json = resolve_bpf_skel_entities(&entities, bpf_skel_json)?;
     Ok(new_skel_json)
-}
-
-#[cfg_attr(not(test), allow(dead_code))]
-pub fn parse_source_documents(
-    args: &Options,
-    source_path: &str,
-    bpf_skel_json: Value,
-) -> Result<Value> {
-    parse_source_documents_with_include_base(args, source_path, source_path, bpf_skel_json)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- replace CodeQL autobuild with an explicit `make` step
- skip the branch release publishing job unless the workflow is running on `master`

## Notes
- this PR no longer contains any `ecc` compiler workaround for `#329`
- `#329` is being handled as a usage/documentation issue instead of a source-rewrite change in `ecc`

## Validation
- not run locally; workflow-only changes
