### PR TITLE
ci: fix immutable GitHub release publishing

### DIFF
--- a/.github/workflows/ecc-binary.yml
+++ b/.github/workflows/ecc-binary.yml
@@ -392,7 +392,7 @@ jobs:
     needs: [create-release-version, build-ecc-binary-x86, build-ecc-binary-aarch64]
     runs-on: ubuntu-latest
     concurrency:
-      group: release-${{ needs.create-release-version.outputs.version }}
+      group: ${{ github.workflow }}-${{ needs.create-release-version.outputs.version }}-${{ github.ref_name }}
       cancel-in-progress: false
     steps:
       - name: Download build results
@@ -405,16 +405,30 @@ jobs:
       - name: Copy ecc binary x86_64 to ecc
         run: |
           cp ./results/ecc-x86_64/ecc-x86_64 ./results/ecc-x86_64/ecc
-      - name: Publish
-        if:   github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository_owner == 'eunomia-bpf'
-        uses: softprops/action-gh-release@v1
-        with:
-            files: |
-              ./results/ecc-x86_64/ecc
-              ./results/ecc-x86_64/ecc-x86_64
-              ./results/ecc-aarch64/ecc-aarch64
-            prerelease: false
-            tag_name: ${{ needs.create-release-version.outputs.version }}
-            generate_release_notes: true
+      - name: Ensure draft release exists
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository_owner == 'eunomia-bpf'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ needs.create-release-version.outputs.version }}
+        run: |
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            echo "Release $RELEASE_TAG already exists"
+          elif ! gh release create "$RELEASE_TAG" --draft --generate-notes --target "$GITHUB_SHA"; then
+            echo "Release creation raced with another workflow, re-checking state"
+            gh release view "$RELEASE_TAG" >/dev/null
+          fi
+      - name: Upload ecc assets to draft release
+        if:   github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository_owner == 'eunomia-bpf'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ needs.create-release-version.outputs.version }}
+        run: |
+          if [ "$(gh release view "$RELEASE_TAG" --json isDraft --jq .isDraft)" != "true" ]; then
+            echo "Release $RELEASE_TAG is already published and cannot accept new assets"
+            exit 1
+          fi
+          gh release upload "$RELEASE_TAG" \
+            ./results/ecc-x86_64/ecc \
+            ./results/ecc-x86_64/ecc-x86_64 \
+            ./results/ecc-aarch64/ecc-aarch64 \
+            --clobber

--- a/.github/workflows/ecli-binary.yaml
+++ b/.github/workflows/ecli-binary.yaml
@@ -453,7 +453,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [create-release-version, build-full-client, build-http-only-client, build-native-only-client, build-ecli-server, build-full-client-and-server-aarch64]
     concurrency:
-      group: release-${{ needs.create-release-version.outputs.version }}
+      group: ${{ github.workflow }}-${{ needs.create-release-version.outputs.version }}-${{ github.ref_name }}
       cancel-in-progress: false
     steps:
       - name: Download build results
@@ -469,13 +469,58 @@ jobs:
           echo "upload_files<<$EOF" >> "$GITHUB_OUTPUT"
           echo "$FILES" >> "$GITHUB_OUTPUT"
           echo "$EOF" >> "$GITHUB_OUTPUT"
-      - name: Publish
+      - name: Ensure draft release exists
         if:   github.event_name == 'push' && github.ref == 'refs/heads/master' && ( github.repository_owner == 'eunomia-bpf' || github.repository_owner == 'officeyutong')
-        uses: softprops/action-gh-release@v1
-        with:
-            files: ${{steps.list-files.outputs.upload_files}}
-            prerelease: false
-            tag_name: ${{ needs.create-release-version.outputs.version }}
-            generate_release_notes: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ needs.create-release-version.outputs.version }}
+        run: |
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            echo "Release $RELEASE_TAG already exists"
+          elif ! gh release create "$RELEASE_TAG" --draft --generate-notes --target "$GITHUB_SHA"; then
+            echo "Release creation raced with another workflow, re-checking state"
+            gh release view "$RELEASE_TAG" >/dev/null
+          fi
+      - name: Upload ecli assets to draft release
+        if:   github.event_name == 'push' && github.ref == 'refs/heads/master' && ( github.repository_owner == 'eunomia-bpf' || github.repository_owner == 'officeyutong')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ needs.create-release-version.outputs.version }}
+        shell: bash
+        run: |
+          if [ "$(gh release view "$RELEASE_TAG" --json isDraft --jq .isDraft)" != "true" ]; then
+            echo "Release $RELEASE_TAG is already published and cannot accept new assets"
+            exit 1
+          fi
+          mapfile -t files < <(find ./results -type f | sort)
+          gh release upload "$RELEASE_TAG" "${files[@]}" --clobber
+      - name: Wait for ecc assets
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository_owner == 'eunomia-bpf'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ needs.create-release-version.outputs.version }}
+        shell: bash
+        run: |
+          for attempt in $(seq 1 30); do
+            mapfile -t assets < <(gh release view "$RELEASE_TAG" --json assets --jq '.assets[].name')
+            missing=0
+            for expected in ecc ecc-x86_64 ecc-aarch64; do
+              if ! printf '%s\n' "${assets[@]}" | grep -Fxq "$expected"; then
+                missing=1
+                break
+              fi
+            done
+            if [ "$missing" -eq 0 ]; then
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "Timed out waiting for ecc assets to arrive on $RELEASE_TAG"
+          exit 1
+      - name: Publish draft release
+        if:   github.event_name == 'push' && github.ref == 'refs/heads/master' && ( github.repository_owner == 'eunomia-bpf' || github.repository_owner == 'officeyutong')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ needs.create-release-version.outputs.version }}
+        run: |
+          gh release edit "$RELEASE_TAG" --draft=false

--- a/.github/workflows/example-publlish.yml
+++ b/.github/workflows/example-publlish.yml
@@ -76,7 +76,7 @@ jobs:
       - name: test examples
         run: |
           . $HOME/.cargo/env
-          SKIP_TESTS=profile make -C examples/tests test
+          SKIP_TESTS="profile bootstrap" make -C examples/tests test
 
       - uses: JamesIves/github-pages-deploy-action@v4.4.1
         if: ${{ github.event_name == 'push' }}


### PR DESCRIPTION
## Summary\n- switch ecc/ecli publishing to draft release uploads, then publish after all assets are present\n- scope release job concurrency by workflow and ref so non-master/manual runs do not block master releases\n- skip the bootstrap example in the gh-pages container publish job where the required tracepoint is unavailable\n\n## Verification\n- parsed the updated workflow YAML with Ruby\n- confirmed the current master failure is `Cannot upload assets to an immutable release` from the ecc release job\n- confirmed the current master `Deploy examples` failure is the bootstrap tracepoint attach failure inside the ubuntu:24.04 container\n