### PR TITLE
compiler: fix spurious runqlat diagnostics

### DIFF
--- a/compiler/cmd/src/bpf_compiler/mod.rs
+++ b/compiler/cmd/src/bpf_compiler/mod.rs
@@ -5,13 +5,12 @@
 //!
 use crate::bpf_compiler::standalone::build_standalone_executable;
 use crate::config::{
-    fetch_btfhub_repo, generate_tailored_btf, get_base_dir_include_args, get_bpf_sys_include_args,
-    get_bpftool_path, get_eunomia_include_args, package_btfhub_tar, Options,
+    fetch_btfhub_repo, generate_tailored_btf, get_bpf_compile_args, get_bpftool_path,
+    package_btfhub_tar, Options,
 };
 use crate::document_parser::parse_source_documents;
 use crate::export_types::{add_unused_ptr_for_structs, find_all_export_structs};
 use crate::handle_std_command_with_log;
-use crate::helper::get_target_arch;
 use crate::wasm::pack_object_in_wasm_header;
 use anyhow::{anyhow, bail, Context, Result};
 use flate2::write::ZlibEncoder;
@@ -36,17 +35,11 @@ fn compile_bpf_object(
         "Compiling bpf object: output: {:?}, source: {:?}",
         output_path, source_path
     );
-    let bpf_sys_include = get_bpf_sys_include_args(&args.compile_opts)?;
-    debug!("Sys include: {:?}", bpf_sys_include);
-    let target_arch = get_target_arch();
+    let clang_compile_args = get_bpf_compile_args(args, &args.compile_opts.source_path)?;
+    debug!("Clang args: {:?}", clang_compile_args);
 
     let mut cmd = std::process::Command::new(&args.compile_opts.parameters.clang_bin);
-    cmd.args(["-g", "-O2", "-target", "bpf", "-Wno-unknown-attributes"])
-        .arg(format!("-D__TARGET_ARCH_{}", target_arch))
-        .args(bpf_sys_include)
-        .args(get_eunomia_include_args(args)?)
-        .args(&args.compile_opts.parameters.additional_cflags)
-        .args(get_base_dir_include_args(source_path)?)
+    cmd.args(clang_compile_args)
         .arg("-c")
         .arg(source_path)
         .arg("-o")

--- a/compiler/cmd/src/config/mod.rs
+++ b/compiler/cmd/src/config/mod.rs
@@ -227,6 +227,29 @@ pub fn get_bpf_sys_include_args(args: &CompileArgs) -> Result<Vec<String>> {
         .collect())
 }
 
+/// Get shared clang arguments for compiling or parsing a bpf source file.
+pub fn get_bpf_compile_args(
+    args: &Options,
+    include_base_path: impl AsRef<Path>,
+) -> Result<Vec<String>> {
+    let bpf_sys_include = get_bpf_sys_include_args(&args.compile_opts)?;
+    let target_arch = get_target_arch();
+
+    let mut compile_args = vec![
+        "-g".to_string(),
+        "-O2".to_string(),
+        "-target".to_string(),
+        "bpf".to_string(),
+        "-Wno-unknown-attributes".to_string(),
+        format!("-D__TARGET_ARCH_{target_arch}"),
+    ];
+    compile_args.extend(bpf_sys_include);
+    compile_args.extend(get_eunomia_include_args(args)?);
+    compile_args.extend(args.compile_opts.parameters.additional_cflags.clone());
+    compile_args.extend(get_base_dir_include_args(include_base_path)?);
+    Ok(compile_args)
+}
+
 /// Get eunomia home include dirs
 pub fn get_eunomia_include_args(args: &Options) -> Result<Vec<String>> {
     let eunomia_tmp_workspace = args.tmpdir.path();

--- a/compiler/cmd/src/config/tests.rs
+++ b/compiler/cmd/src/config/tests.rs
@@ -10,11 +10,18 @@ use tempfile::TempDir;
 
 use crate::config::{init_eunomia_workspace, EunomiaWorkspace};
 
-use super::{get_base_dir_include_args, CompileArgs, Options};
+use super::{get_base_dir_include_args, get_bpf_compile_args, CompileArgs, Options};
 
 fn init_options(copt: CompileArgs) {
     let mut opts = Options::init(copt, TempDir::new().unwrap()).unwrap();
     opts.compile_opts.parameters.no_generate_package_json = true;
+}
+
+fn create_initialized_options(source_path: &str) -> Options {
+    let tmp_workspace = TempDir::new().unwrap();
+    init_eunomia_workspace(&tmp_workspace).unwrap();
+    let compile_opts = CompileArgs::parse_from(["ecc", source_path]);
+    Options::init(compile_opts, tmp_workspace).unwrap()
 }
 
 #[test]
@@ -87,4 +94,23 @@ fn test_init_eunomia_workspace() {
 
     // test default workspace
     EunomiaWorkspace::init(CompileArgs::parse_from(&["ecc", "../test/client.bpf.c"])).unwrap();
+}
+
+#[test]
+fn test_get_bpf_compile_args_split_target_and_use_source_dir() {
+    let tmp_source_dir = TempDir::new().unwrap();
+    let source_dir = tmp_source_dir.path().join("src");
+    fs::create_dir_all(&source_dir).unwrap();
+    let source_path = source_dir.join("test.bpf.c");
+    fs::write(&source_path, "int x;").unwrap();
+
+    let args = create_initialized_options(source_path.to_str().unwrap());
+    let compile_args = get_bpf_compile_args(&args, &args.compile_opts.source_path).unwrap();
+    let source_include = format!("-I{}", source_dir.canonicalize().unwrap().display());
+
+    assert!(compile_args
+        .windows(2)
+        .any(|window| window == ["-target", "bpf"]));
+    assert!(!compile_args.iter().any(|arg| arg == "-target bpf"));
+    assert!(compile_args.iter().any(|arg| arg == &source_include));
 }

--- a/compiler/cmd/src/document_parser.rs
+++ b/compiler/cmd/src/document_parser.rs
@@ -7,11 +7,8 @@ extern crate clang;
 use std::path::Path;
 use std::result::Result::Ok;
 
-use crate::config::get_base_dir_include_args;
-use crate::config::get_bpf_sys_include_args;
-use crate::config::get_eunomia_include_args;
+use crate::config::get_bpf_compile_args;
 use crate::config::Options;
-use crate::helper::get_target_arch;
 use anyhow::anyhow;
 use anyhow::Context;
 use anyhow::Result;
@@ -29,22 +26,7 @@ fn parse_source_files<'a>(
     args: &'a Options,
     source_path: &'a Path,
 ) -> Result<TranslationUnit<'a>> {
-    let bpf_sys_include = get_bpf_sys_include_args(&args.compile_opts)?;
-    let target_arch = get_target_arch();
-    let target_arch = format!("-D__TARGET_ARCH_{target_arch}");
-    let eunomia_include = get_eunomia_include_args(args)?;
-    let base_dir_include = get_base_dir_include_args(source_path)?;
-    let mut compile_args = vec![
-        "-g".to_string(),
-        "-O2".to_string(),
-        "-target bpf".to_string(),
-        "-Wno-unknown-attributes".to_string(),
-        target_arch,
-    ];
-    compile_args.extend(bpf_sys_include);
-    compile_args.extend(eunomia_include);
-    compile_args.extend(base_dir_include);
-    compile_args.extend(args.compile_opts.parameters.additional_cflags.clone());
+    let compile_args = get_bpf_compile_args(args, source_path)?;
 
     // Parse a source file into a translation unit
     let tu = index


### PR DESCRIPTION
## Summary
- share one clang argument builder between the real compile path and the document parser
- pass -target and bpf as separate clang args so libclang stops reporting a fake unknown argument error during document parsing
- always derive the local include base from the original source path, so header-export builds still work with a separate --output-path

Fixes #294

## Testing
- cargo test --manifest-path compiler/cmd/Cargo.toml config::tests -- --nocapture
- env LIBCLANG_PATH=/usr/lib/llvm-18/lib cargo run --manifest-path compiler/cmd/Cargo.toml -- /home/yunwei37/workspace/eunomia-bpf-294/examples/bpftools/runqlat/runqlat.bpf.c /home/yunwei37/workspace/eunomia-bpf-294/examples/bpftools/runqlat/runqlat.h
- env LIBCLANG_PATH=/usr/lib/llvm-18/lib cargo run --manifest-path compiler/cmd/Cargo.toml -- /home/yunwei37/workspace/eunomia-bpf-294/examples/bpftools/runqlat/runqlat.bpf.c /home/yunwei37/workspace/eunomia-bpf-294/examples/bpftools/runqlat/runqlat.h --output-path /tmp/issue294-fixed