### PR TITLE
bpf-loader: suppress harmless tc reattach warning

### DIFF
--- a/bpf-loader-rs/bpf-loader-lib/src/helper/libbpf_log.rs
+++ b/bpf-loader-rs/bpf-loader-lib/src/helper/libbpf_log.rs
@@ -1,0 +1,67 @@
+//!  SPDX-License-Identifier: MIT
+//!
+//! Copyright (c) 2023, eunomia-bpf
+//! All rights reserved.
+//!
+
+use std::sync::Once;
+
+use libbpf_rs::{set_print, PrintLevel};
+
+static INIT_LIBBPF_LOGGING: Once = Once::new();
+const HARMLESS_TC_REATTACH_WARNING: &str =
+    "Kernel error message: Exclusivity flag on, cannot modify";
+
+fn should_suppress_libbpf_message(level: PrintLevel, msg: &str) -> bool {
+    level == PrintLevel::Warn && msg.contains(HARMLESS_TC_REATTACH_WARNING)
+}
+
+fn log_libbpf_message(level: PrintLevel, msg: String) {
+    let msg = msg.trim_end();
+    if msg.is_empty() || should_suppress_libbpf_message(level, msg) {
+        return;
+    }
+
+    if level == PrintLevel::Warn {
+        log::warn!("{}", msg);
+    } else {
+        log::info!("{}", msg);
+    }
+}
+
+pub(crate) fn init_libbpf_logging() {
+    INIT_LIBBPF_LOGGING.call_once(|| {
+        set_print(Some((PrintLevel::Info, log_libbpf_message)));
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use libbpf_rs::PrintLevel;
+
+    use super::should_suppress_libbpf_message;
+
+    #[test]
+    fn suppresses_harmless_tc_reattach_warning() {
+        assert!(should_suppress_libbpf_message(
+            PrintLevel::Warn,
+            "libbpf: Kernel error message: Exclusivity flag on, cannot modify\n"
+        ));
+    }
+
+    #[test]
+    fn keeps_other_libbpf_warnings_visible() {
+        assert!(!should_suppress_libbpf_message(
+            PrintLevel::Warn,
+            "libbpf: Kernel error message: Filter already exists\n"
+        ));
+    }
+
+    #[test]
+    fn does_not_suppress_tc_reattach_warning_at_info_level() {
+        assert!(!should_suppress_libbpf_message(
+            PrintLevel::Info,
+            "libbpf: Kernel error message: Exclusivity flag on, cannot modify\n"
+        ));
+    }
+}

--- a/bpf-loader-rs/bpf-loader-lib/src/helper/mod.rs
+++ b/bpf-loader-rs/bpf-loader-lib/src/helper/mod.rs
@@ -5,4 +5,5 @@
 //!
 
 pub(crate) mod btf;
+pub(crate) mod libbpf_log;
 pub(crate) mod log2_hist;

--- a/bpf-loader-rs/bpf-loader-lib/src/skeleton/builder.rs
+++ b/bpf-loader-rs/bpf-loader-lib/src/skeleton/builder.rs
@@ -18,7 +18,7 @@ use std::{
 use crate::{
     btf_container::BtfContainer,
     elf_container::ElfContainer,
-    helper::btf::create_elf_with_btf_section,
+    helper::{btf::create_elf_with_btf_section, libbpf_log::init_libbpf_logging},
     meta::{ComposedObject, EunomiaObjectMeta, RunnerConfig},
     skeleton::{BTF_PATH_ENV_NAME, VMLINUX_BTF_PATH},
 };
@@ -78,6 +78,7 @@ impl<'a> BpfSkeletonBuilder<'a> {
     }
     /// Build (open) the skeleton
     pub fn build(self) -> Result<PreLoadBpfSkeleton> {
+        init_libbpf_logging();
         let mut open_bpts = ObjectBuilder::default()
             .opts(self.object_meta.bpf_skel.obj_name.as_bytes().as_ptr() as *const c_char);
         // Why we put path_holder here? to keep its iveness until this function returns, so that we can safely use the pointers to the underlying data in bpf_object_openopts


### PR DESCRIPTION
## Summary
- initialize libbpf logging once in bpf-loader-lib before opening BPF objects
- route libbpf output through the Rust logger instead of raw stderr
- suppress the known harmless tc reattach warning for existing clsact qdiscs while leaving other warnings visible

Fixes #245

## Testing
- cargo test --manifest-path bpf-loader-rs/Cargo.toml -p bpf-loader-lib helper::libbpf_log::tests -- --nocapture
- cargo build --manifest-path ecli/Cargo.toml -p ecli-rs
- sudo timeout -s INT 3s ecli/target/debug/ecli-rs run bpf-loader-rs/bpf-loader-lib/assets/simple_prog_6/package.json
- sudo timeout -s INT 3s ecli/target/debug/ecli-rs run bpf-loader-rs/bpf-loader-lib/assets/simple_prog_6/package.json

## Review
- claude -p review on the final patch: No findings.