### PR TITLE
ci: preserve GitHub Pages example assets

### DIFF
--- a/.github/scripts/build-gh-pages-assets.sh
+++ b/.github/scripts/build-gh-pages-assets.sh
@@ -1,26 +1,57 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
+shopt -s nullglob
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 examples_root="${repo_root}/examples/bpftools"
 ecc_bin="${ECC_BIN:-${repo_root}/compiler/workspace/bin/ecc-rs}"
+wasi_clang="/opt/wasi-sdk/bin/clang"
 
 if [[ ! -x "${ecc_bin}" ]]; then
   echo "ecc-rs is not available at ${ecc_bin}" >&2
   exit 1
 fi
 
+assert_file_exists() {
+  local path="$1"
+
+  if [[ ! -f "${path}" ]]; then
+    echo "Expected asset is missing: ${path}" >&2
+    exit 1
+  fi
+}
+
+get_example_source() {
+  local dir="$1"
+  local sources=("${dir}"/*.bpf.c)
+
+  if [[ ${#sources[@]} -eq 0 ]]; then
+    echo "Expected exactly one *.bpf.c in ${dir}, found none" >&2
+    exit 1
+  fi
+  if [[ ${#sources[@]} -ne 1 ]]; then
+    echo "Expected exactly one *.bpf.c in ${dir}, found ${#sources[@]}" >&2
+    exit 1
+  fi
+  printf '%s\n' "${sources[0]}"
+}
+
+get_example_header() {
+  local source="$1"
+  local stem
+  stem="$(basename "${source}" .bpf.c)"
+  printf '%s\n' "${source%.bpf.c}.h"
+}
+
 build_package_asset() {
   local dir="$1"
+  local source
+  source="$(get_example_source "${dir}")"
   local name
-  name="$(basename "${dir}")"
-  local source="${dir}/${name}.bpf.c"
-  local header="${dir}/${name}.h"
-
-  if [[ ! -f "${source}" ]]; then
-    return 0
-  fi
+  name="$(basename "${source}" .bpf.c)"
+  local header
+  header="$(get_example_header "${source}")"
 
   echo "Building ${name}/package.json"
   if [[ -f "${header}" ]]; then
@@ -28,6 +59,105 @@ build_package_asset() {
   else
     "${ecc_bin}" "${source}"
   fi
+  assert_file_exists "${dir}/package.json"
+}
+
+build_passthrough_wasm_asset() {
+  local dir="$1"
+  local source
+  source="$(get_example_source "${dir}")"
+  local name
+  name="$(basename "${source}" .bpf.c)"
+  local header
+  header="$(get_example_header "${source}")"
+  local generated_source
+  generated_source="$(mktemp "${dir}/.${name}.gh-pages-app.XXXXXX.c")"
+
+  cat > "${generated_source}" <<'EOF'
+#include <stdio.h>
+#include <string.h>
+
+#include "ewasm-skel.h"
+
+int create_bpf(char *ebpf_json, int str_len);
+int run_bpf(int id);
+int wait_and_poll_bpf(int id);
+
+int bpf_main(char *env_json, int str_len)
+{
+    (void)env_json;
+    (void)str_len;
+
+    int res = create_bpf(program_data, strlen(program_data));
+    if (res < 0) {
+        printf("create_bpf failed %d\n", res);
+        return -1;
+    }
+    res = run_bpf(res);
+    if (res < 0) {
+        printf("run_bpf failed %d\n", res);
+        return -1;
+    }
+    res = wait_and_poll_bpf(res);
+    if (res < 0) {
+        printf("wait_and_poll_bpf failed %d\n", res);
+        return -1;
+    }
+    return 0;
+}
+
+int process_event(int ctx, char *event_json, int str_len)
+{
+    (void)ctx;
+    printf("%.*s\n", str_len, event_json);
+    return -1;
+}
+EOF
+
+  echo "Building ${name}/app.wasm"
+  if [[ -f "${header}" ]]; then
+    "${ecc_bin}" "${source}" "${header}" --wasm-header
+  else
+    "${ecc_bin}" "${source}" --wasm-header
+  fi
+  assert_file_exists "${dir}/ewasm-skel.h"
+
+  "${wasi_clang}" \
+    --target=wasm32-wasi \
+    -O0 -z stack-size=4096 -Wl,--initial-memory=65536 \
+    --sysroot=/opt/wasi-sdk/share/wasi-sysroot \
+    -I "${dir}" \
+    -Wl,--export=all \
+    -Wl,--export=bpf_main \
+    -Wl,--export=process_event \
+    -Wl,--strip-all,--no-entry \
+    -Wl,--allow-undefined \
+    -o "${dir}/${name}.wasm" "${generated_source}"
+
+  cp "${dir}/${name}.wasm" "${dir}/app.wasm"
+  rm -f "${generated_source}"
+
+  assert_file_exists "${dir}/${name}.wasm"
+  assert_file_exists "${dir}/app.wasm"
+}
+
+build_sigsnoop_wasm_asset() {
+  local dir="${examples_root}/sigsnoop"
+
+  [[ -x "${dir}/build.sh" ]] || {
+    echo "Missing executable sigsnoop build script at ${dir}/build.sh" >&2
+    exit 1
+  }
+
+  echo "Building sigsnoop/app.wasm"
+  (
+    cd "${dir}"
+    ./build.sh
+    cp sigsnoop.wasm app.wasm
+  )
+
+  assert_file_exists "${dir}/sigsnoop.wasm"
+  assert_file_exists "${dir}/app.wasm"
 }
 
 for dir in "${examples_root}"/*; do
@@ -35,14 +165,10 @@ for dir in "${examples_root}"/*; do
   build_package_asset "${dir}"
 done
 
-sigsnoop_dir="${examples_root}/sigsnoop"
-if [[ -x /opt/wasi-sdk/bin/clang && -x "${sigsnoop_dir}/build.sh" ]]; then
-  echo "Building sigsnoop Wasm assets"
-  (
-    cd "${sigsnoop_dir}"
-    ./build.sh
-    cp sigsnoop.wasm app.wasm
-  )
-else
-  echo "Skipping sigsnoop Wasm assets; /opt/wasi-sdk/bin/clang or build.sh is missing" >&2
-fi
+[[ -x "${wasi_clang}" ]] || {
+  echo "Missing required Wasm compiler at ${wasi_clang}" >&2
+  exit 1
+}
+
+build_sigsnoop_wasm_asset
+build_passthrough_wasm_asset "${examples_root}/opensnoop"

--- a/.github/scripts/build-gh-pages-assets.sh
+++ b/.github/scripts/build-gh-pages-assets.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+examples_root="${repo_root}/examples/bpftools"
+ecc_bin="${ECC_BIN:-${repo_root}/compiler/workspace/bin/ecc-rs}"
+
+if [[ ! -x "${ecc_bin}" ]]; then
+  echo "ecc-rs is not available at ${ecc_bin}" >&2
+  exit 1
+fi
+
+build_package_asset() {
+  local dir="$1"
+  local name
+  name="$(basename "${dir}")"
+  local source="${dir}/${name}.bpf.c"
+  local header="${dir}/${name}.h"
+
+  if [[ ! -f "${source}" ]]; then
+    return 0
+  fi
+
+  echo "Building ${name}/package.json"
+  if [[ -f "${header}" ]]; then
+    "${ecc_bin}" "${source}" "${header}"
+  else
+    "${ecc_bin}" "${source}"
+  fi
+}
+
+for dir in "${examples_root}"/*; do
+  [[ -d "${dir}" ]] || continue
+  build_package_asset "${dir}"
+done
+
+sigsnoop_dir="${examples_root}/sigsnoop"
+if [[ -x /opt/wasi-sdk/bin/clang && -x "${sigsnoop_dir}/build.sh" ]]; then
+  echo "Building sigsnoop Wasm assets"
+  (
+    cd "${sigsnoop_dir}"
+    ./build.sh
+    cp sigsnoop.wasm app.wasm
+  )
+else
+  echo "Skipping sigsnoop Wasm assets; /opt/wasi-sdk/bin/clang or build.sh is missing" >&2
+fi

--- a/.github/scripts/build-gh-pages-assets.sh
+++ b/.github/scripts/build-gh-pages-assets.sh
@@ -39,8 +39,6 @@ get_example_source() {
 
 get_example_header() {
   local source="$1"
-  local stem
-  stem="$(basename "${source}" .bpf.c)"
   printf '%s\n' "${source%.bpf.c}.h"
 }
 

--- a/.github/workflows/example-publlish.yml
+++ b/.github/workflows/example-publlish.yml
@@ -68,6 +68,11 @@ jobs:
           make -C examples/tests install-deps
           make -C examples/tests install-wasm-clang
 
+      - name: Build GitHub Pages assets
+        run: |
+          . $HOME/.cargo/env
+          ./.github/scripts/build-gh-pages-assets.sh
+
       - name: test build runners
         run: |
           . $HOME/.cargo/env

--- a/examples/bpftools/opensnoop/.gitignore
+++ b/examples/bpftools/opensnoop/.gitignore
@@ -2,6 +2,8 @@
 package.json
 eunomia-exporter
 ecli
+*.wasm
 *.bpf.o
 *.skel.json
 *.skel.yaml
+ewasm-skel.h


### PR DESCRIPTION
## Summary
- build GitHub Pages example assets before deploying `examples/bpftools`
- generate `package.json` for every published example directory with fail-fast source discovery
- keep the historical Wasm compatibility paths for both `sigsnoop/app.wasm` and `opensnoop/app.wasm`
- fail the publish step when required Wasm compatibility assets cannot be produced

## Why
The existing workflow deploys `examples/bpftools` to GitHub Pages, but some historical assets stopped being published because package generation happened only in test paths that now skip examples like `sigsnoop`, `opensnoop`, and `runqlat`.

That broke legacy URLs such as:
- `https://eunomia-bpf.github.io/eunomia-bpf/sigsnoop/package.json`
- `https://eunomia-bpf.github.io/eunomia-bpf/sigsnoop/app.wasm`
- `https://eunomia-bpf.github.io/eunomia-bpf/opensnoop/package.json`
- `https://eunomia-bpf.github.io/eunomia-bpf/opensnoop/app.wasm`

## Validation
- ran `bash -n .github/scripts/build-gh-pages-assets.sh`
- ran `ECC_BIN=... ./.github/scripts/build-gh-pages-assets.sh`
- verified local outputs including `examples/bpftools/sigsnoop/package.json`, `examples/bpftools/sigsnoop/app.wasm`, `examples/bpftools/opensnoop/package.json`, `examples/bpftools/opensnoop/app.wasm`, and `examples/bpftools/runqlat/package.json`