### PR TITLE
ecc: simplify libclang initialization and remove thread-local/singleton workarounds

### DIFF
--- a/compiler/cmd/src/bpf_compiler/mod.rs
+++ b/compiler/cmd/src/bpf_compiler/mod.rs
@@ -106,18 +106,8 @@ fn do_compile(args: &Options, temp_source_file: impl AsRef<Path>) -> Result<()> 
     let bpf_skel_json = get_bpf_skel_json(&output_bpf_object_path, args)?;
     let bpf_skel = serde_json::from_str::<Value>(&bpf_skel_json)
         .with_context(|| anyhow!("Failed to parse json skeleton"))?;
-    let bpf_skel_with_doc =
-        match parse_source_documents(args, &args.compile_opts.source_path, bpf_skel.clone()) {
-            Ok(v) => v,
-            Err(e) => {
-                if e.to_string()
-                    != "Failed to create Clang instance: an instance of `Clang` already exists"
-                {
-                    panic!("failed to parse source documents: {}", e);
-                };
-                bpf_skel
-            }
-        };
+    let bpf_skel_with_doc = parse_source_documents(args, &args.compile_opts.source_path, bpf_skel)
+        .with_context(|| anyhow!("Failed to parse source documents"))?;
     meta_json["bpf_skel"] = bpf_skel_with_doc;
 
     // compile export types

--- a/compiler/cmd/src/document_parser.rs
+++ b/compiler/cmd/src/document_parser.rs
@@ -9,11 +9,11 @@ use std::result::Result::Ok;
 
 use crate::config::get_bpf_compile_args;
 use crate::config::Options;
+use crate::libclang::with_clang;
 use anyhow::anyhow;
 use anyhow::Context;
 use anyhow::Result;
 use clang::documentation::CommentChild;
-use clang::Clang;
 use clang::Entity;
 use clang::EntityKind;
 use clang::Index;
@@ -228,40 +228,39 @@ pub fn parse_source_documents(
     source_path: &str,
     bpf_skel_json: Value,
 ) -> Result<Value> {
-    // Acquire an instance of `Clang`
-    let clang = match Clang::new() {
-        Ok(clang) => clang,
-        Err(e) => {
-            return Err(anyhow!("Failed to create Clang instance: {}", e));
-        }
-    };
-    // Create a new `Index`
-    let index = Index::new(&clang, false, true);
-    let _source_path = Path::new(source_path);
-    let canonic_source_path = _source_path.canonicalize().unwrap();
-    let tu = parse_source_files(&index, args, &canonic_source_path)?;
+    let source_path = Path::new(source_path);
+    let canonic_source_path = source_path.canonicalize().with_context(|| {
+        anyhow!(
+            "Failed to canonicalize source path: {}",
+            source_path.display()
+        )
+    })?;
 
-    // Get the entities in this translation unit
-    let entities = tu
-        .get_entity()
-        .get_children()
-        .into_iter()
-        .filter(|e| {
-            if let Some(location) = e.get_location() {
-                if let Some(file) = location.get_file_location().file {
-                    if file.get_path() == canonic_source_path {
-                        return true;
+    with_clang(|clang| {
+        let index = Index::new(clang, false, true);
+        let tu = parse_source_files(&index, args, &canonic_source_path)?;
+
+        // Get the entities in this translation unit
+        let entities = tu
+            .get_entity()
+            .get_children()
+            .into_iter()
+            .filter(|e| {
+                if let Some(location) = e.get_location() {
+                    if let Some(file) = location.get_file_location().file {
+                        if file.get_path() == canonic_source_path {
+                            return true;
+                        }
                     }
                 }
-            }
-            false
-        })
-        .collect::<Vec<_>>();
+                false
+            })
+            .collect::<Vec<_>>();
 
-    // resolve comments for section data and functions, maps
-    // find the entity with the same name as the names in the json skeleton
-    let new_skel_json = resolve_bpf_skel_entities(&entities, bpf_skel_json)?;
-    Ok(new_skel_json)
+        // resolve comments for section data and functions, maps
+        // find the entity with the same name as the names in the json skeleton
+        resolve_bpf_skel_entities(&entities, bpf_skel_json)
+    })
 }
 
 #[cfg(test)]
@@ -353,18 +352,8 @@ mod test {
                 }
             ],
             "maps":[], "progs":[]}),
-        );
-        let skel = match skel {
-            Ok(skel) => skel,
-            Err(e) => {
-                if e.to_string()
-                    != "Failed to create Clang instance: an instance of `Clang` already exists"
-                {
-                    panic!("failed to parse source documents: {}", e);
-                }
-                return;
-            }
-        };
+        )
+        .unwrap();
         let rodata = &skel["data_sections"][0];
         assert_eq!(rodata, &test_case_res);
     }
@@ -399,18 +388,8 @@ mod test {
                     "name": "handle_exit"
                 }
             ],"maps":[], "data_sections":[]}),
-        );
-        let skel = match skel {
-            Ok(skel) => skel,
-            Err(e) => {
-                if e.to_string()
-                    != "Failed to create Clang instance: an instance of `Clang` already exists"
-                {
-                    panic!("failed to parse source documents: {}", e);
-                }
-                return;
-            }
-        };
+        )
+        .unwrap();
         let handle_exec = &skel["progs"];
         assert_eq!(handle_exec, &test_case_res);
     }
@@ -432,18 +411,8 @@ mod test {
                     "name": "exec_start",
                 }
             ], "progs":[], "data_sections":[]}),
-        );
-        let skel = match skel {
-            Ok(skel) => skel,
-            Err(e) => {
-                if e.to_string()
-                    != "Failed to create Clang instance: an instance of `Clang` already exists"
-                {
-                    panic!("failed to parse source documents: {}", e);
-                }
-                return;
-            }
-        };
+        )
+        .unwrap();
         let exec_start = &skel["maps"][0];
         assert_eq!(exec_start, &test_case_res);
     }

--- a/compiler/cmd/src/libclang.rs
+++ b/compiler/cmd/src/libclang.rs
@@ -1,0 +1,89 @@
+//!  SPDX-License-Identifier: MIT
+//!
+//! Copyright (c) 2023, eunomia-bpf
+//! All rights reserved.
+//!
+use std::{
+    path::PathBuf,
+    str::FromStr,
+    sync::{Arc, Mutex, OnceLock},
+};
+
+use anyhow::{anyhow, Result};
+use clang::Clang;
+use log::warn;
+use walkdir::WalkDir;
+
+static LIBCLANG_LIBRARY: OnceLock<Arc<clang_sys::SharedLibrary>> = OnceLock::new();
+static LIBCLANG_SESSION_LOCK: Mutex<()> = Mutex::new(());
+
+fn configure_appimage_libclang_path() -> Result<()> {
+    let Ok(search_paths) = std::env::var("EUNOMIA_APPIMAGE_DEFINED_LD_LIBRARY_PATH") else {
+        return Ok(());
+    };
+
+    let mut libclang_path = None;
+    for dir in search_paths.split(':') {
+        let dir = PathBuf::from_str(dir)?;
+        if !dir.exists() {
+            continue;
+        }
+        for entry in WalkDir::new(dir) {
+            let entry = entry?;
+            if entry.file_type().is_file()
+                && entry.file_name().to_string_lossy().starts_with("libclang")
+            {
+                libclang_path = entry.path().parent().map(|path| path.to_path_buf());
+            }
+        }
+    }
+
+    if let Some(path) = libclang_path {
+        std::env::set_var("LIBCLANG_PATH", path);
+    } else {
+        warn!("libclang not found in EUNOMIA_APPIMAGE_DEFINED_LD_LIBRARY_PATH. Caution for library version issues.");
+    }
+
+    Ok(())
+}
+
+fn shared_library() -> Result<Arc<clang_sys::SharedLibrary>> {
+    if let Some(library) = LIBCLANG_LIBRARY.get() {
+        return Ok(Arc::clone(library));
+    }
+
+    let library = Arc::new(
+        clang_sys::load_manually()
+            .map_err(|e| anyhow!("Failed to load libclang dynamically at runtime: {}", e))?,
+    );
+    let _ = LIBCLANG_LIBRARY.set(Arc::clone(&library));
+    Ok(library)
+}
+
+struct ThreadLibraryGuard {
+    previous_library: Option<Arc<clang_sys::SharedLibrary>>,
+}
+
+impl ThreadLibraryGuard {
+    fn enter() -> Result<Self> {
+        configure_appimage_libclang_path()?;
+        let library = shared_library()?;
+        let previous_library = clang_sys::set_library(Some(library));
+        Ok(Self { previous_library })
+    }
+}
+
+impl Drop for ThreadLibraryGuard {
+    fn drop(&mut self) {
+        clang_sys::set_library(self.previous_library.take());
+    }
+}
+
+pub(crate) fn with_clang<T>(f: impl FnOnce(&Clang) -> Result<T>) -> Result<T> {
+    let _session_lock = LIBCLANG_SESSION_LOCK
+        .lock()
+        .map_err(|_| anyhow!("libclang session lock poisoned"))?;
+    let _library_guard = ThreadLibraryGuard::enter()?;
+    let clang = Clang::new().map_err(|e| anyhow!("Failed to create Clang instance: {}", e))?;
+    f(&clang)
+}

--- a/compiler/cmd/src/main.rs
+++ b/compiler/cmd/src/main.rs
@@ -8,48 +8,18 @@ mod config;
 mod document_parser;
 mod export_types;
 mod helper;
+mod libclang;
 mod wasm;
 
 #[cfg(test)]
 pub(crate) mod tests;
 
-use std::{path::PathBuf, str::FromStr};
-
 use anyhow::Result;
 use bpf_compiler::*;
 use clap::Parser;
 use config::{CompileArgs, EunomiaWorkspace};
-use log::warn;
-use walkdir::WalkDir;
 
 fn main() -> Result<()> {
-    use anyhow::anyhow;
-    // Searches for the libclang in the appimage runner-defined paths, if applies
-    if let Ok(v) = std::env::var("EUNOMIA_APPIMAGE_DEFINED_LD_LIBRARY_PATH") {
-        let mut libclang_path = None;
-        for dir in v.split(':') {
-            let dir = PathBuf::from_str(dir)?;
-            if dir.exists() {
-                for entry in WalkDir::new(dir).into_iter() {
-                    let entry = entry?;
-                    if entry.file_type().is_file()
-                        && entry.file_name().to_string_lossy().starts_with("libclang")
-                    {
-                        libclang_path =
-                            Some(entry.path().parent().unwrap().to_string_lossy().to_string());
-                    }
-                }
-            }
-        }
-        if let Some(v) = libclang_path {
-            std::env::set_var("LIBCLANG_PATH", v);
-        } else {
-            warn!("libclang not found in EUNOMIA_APPIMAGE_DEFINED_LD_LIBRARY_PATH. Caution for library version issues.");
-        }
-    }
-    clang_sys::load()
-        .map_err(|e| anyhow!("Failed to load libclang dynamically at runtime: {}", e))?;
-
     let args = CompileArgs::parse();
 
     flexi_logger::Logger::try_with_env_or_str(if args.verbose { "debug" } else { "info" })?

--- a/compiler/entry-aarch64.sh
+++ b/compiler/entry-aarch64.sh
@@ -1,2 +1,1 @@
-# Enable LIBCLANG_NOTHREADS so that we only need to load libclang*.so at runtime in the main thread
-LIBCLANG_NOTHREADS=1 /ecc "$(ls /src/*.bpf.c)" "$(ls -h1 /src/*.h)" 
+/ecc "$(ls /src/*.bpf.c)" "$(ls -h1 /src/*.h)"


### PR DESCRIPTION
Fixes #381

## Summary
- centralize libclang discovery/load into a shared helper
- attach libclang on demand in parser/compiler paths instead of depending on main preloading
- stop touching libclang for `--help` / `--version` and remove the dead `LIBCLANG_NOTHREADS` wrapper export

## Testing
- cargo test --manifest-path compiler/cmd/Cargo.toml
- cargo test --manifest-path compiler/cmd/Cargo.toml document_parser -- --nocapture --test-threads=1
- cargo test --manifest-path compiler/cmd/Cargo.toml bpf_compiler::tests::test_compile_bpf -- --nocapture
- LIBCLANG_PATH=/definitely/missing cargo run --manifest-path compiler/cmd/Cargo.toml -- --help
- LIBCLANG_PATH=/definitely/missing cargo run --manifest-path compiler/cmd/Cargo.toml -- --version
