### PR TITLE
compiler: replace regex/dummy-pointer export type extraction and clarify --header-only semantics

### DIFF
--- a/compiler/cmd/src/bpf_compiler/mod.rs
+++ b/compiler/cmd/src/bpf_compiler/mod.rs
@@ -9,7 +9,9 @@ use crate::config::{
     package_btfhub_tar, Options,
 };
 use crate::document_parser::parse_source_documents;
-use crate::export_types::{add_unused_ptr_for_structs, find_all_export_structs};
+use crate::export_types::{
+    add_unused_ptr_for_structs, find_all_export_structs, strip_synthetic_bpf_skel_symbols,
+};
 use crate::handle_std_command_with_log;
 use crate::wasm::pack_object_in_wasm_header;
 use anyhow::{anyhow, bail, Context, Result};
@@ -78,7 +80,7 @@ fn get_export_types_json(
     let output =
         handle_std_command_with_log!(command, "Failed to dump BTF from the compiled file!");
     // filter the output to get the export types json
-    let export_structs = find_all_export_structs(&args.compile_opts)?;
+    let export_structs = find_all_export_structs(args)?;
     let export_types_json: Value =
         serde_json::from_str(&output).with_context(|| anyhow!("Failed to parse btf json"))?;
     let export_types_json = export_types_json["structs"]
@@ -118,7 +120,7 @@ fn do_compile(args: &Options, temp_source_file: impl AsRef<Path>) -> Result<()> 
                 bpf_skel
             }
         };
-    meta_json["bpf_skel"] = bpf_skel_with_doc;
+    meta_json["bpf_skel"] = strip_synthetic_bpf_skel_symbols(bpf_skel_with_doc);
 
     // compile export types
     if !args.compile_opts.export_event_header.is_empty() {
@@ -152,7 +154,7 @@ pub fn compile_bpf(args: &Options) -> Result<()> {
         temp_source_file = args.get_source_file_temp_path();
         // create temp source file
         fs::write(&temp_source_file, source_file_content)?;
-        add_unused_ptr_for_structs(&args.compile_opts, &temp_source_file)?;
+        add_unused_ptr_for_structs(args, &temp_source_file)?;
     }
     do_compile(args, &temp_source_file).with_context(|| anyhow!("Failed to compile"))?;
     if !args.compile_opts.export_event_header.is_empty() {

--- a/compiler/cmd/src/bpf_compiler/mod.rs
+++ b/compiler/cmd/src/bpf_compiler/mod.rs
@@ -10,7 +10,8 @@ use crate::config::{
 };
 use crate::document_parser::parse_source_documents;
 use crate::export_types::{
-    add_unused_ptr_for_structs, find_all_export_structs, strip_synthetic_bpf_skel_symbols,
+    add_unused_ptr_for_structs, find_all_export_structs, get_synthetic_bpf_skel_symbols,
+    strip_synthetic_bpf_skel_symbols,
 };
 use crate::handle_std_command_with_log;
 use crate::wasm::pack_object_in_wasm_header;
@@ -120,7 +121,8 @@ fn do_compile(args: &Options, temp_source_file: impl AsRef<Path>) -> Result<()> 
                 bpf_skel
             }
         };
-    meta_json["bpf_skel"] = strip_synthetic_bpf_skel_symbols(bpf_skel_with_doc);
+    let synthetic_symbols = get_synthetic_bpf_skel_symbols(args)?;
+    meta_json["bpf_skel"] = strip_synthetic_bpf_skel_symbols(bpf_skel_with_doc, &synthetic_symbols);
 
     // compile export types
     if !args.compile_opts.export_event_header.is_empty() {

--- a/compiler/cmd/src/bpf_compiler/tests.rs
+++ b/compiler/cmd/src/bpf_compiler/tests.rs
@@ -6,6 +6,7 @@
 
 const TEMP_EUNOMIA_DIR: &str = "/tmp/eunomia";
 use std::io::Write;
+use std::os::unix::fs::symlink;
 use std::path::PathBuf;
 use std::process::Command;
 use std::{fs, path};
@@ -243,4 +244,50 @@ fn test_compile_header_only_respects_export_annotations_and_hides_dummy_symbols(
             .iter()
             .all(|map| map["ident"].as_str().unwrap_or_default() != "bss"));
     }
+}
+
+#[test]
+fn test_compile_header_only_symlink_preserves_include_root_for_docs() {
+    let output_dir = TempDir::new().unwrap();
+    let real_dir = output_dir.path().join("real");
+    let symlink_dir = output_dir.path().join("link");
+    fs::create_dir_all(&real_dir).unwrap();
+    fs::create_dir_all(&symlink_dir).unwrap();
+
+    let real_header_path = real_dir.join("header_only.h");
+    let symlink_header_path = symlink_dir.join("header_only.h");
+    fs::write(
+        &real_header_path,
+        r#"
+            #include "shared.h"
+
+            /// @export
+            struct selected_event {
+                shared_int_t pid;
+            };
+        "#,
+    )
+    .unwrap();
+    fs::write(symlink_dir.join("shared.h"), "typedef int shared_int_t;\n").unwrap();
+    symlink(&real_header_path, &symlink_header_path).unwrap();
+
+    let tmp_workspace = TempDir::new().unwrap();
+    init_eunomia_workspace(&tmp_workspace).unwrap();
+    let cp_args = CompileArgs::try_parse_from([
+        "ecc",
+        symlink_header_path.to_str().unwrap(),
+        "--header-only",
+        "--output-path",
+        output_dir.path().to_str().unwrap(),
+    ])
+    .unwrap();
+    let args = Options::init(cp_args, tmp_workspace).unwrap();
+
+    compile_bpf(&args).unwrap();
+
+    let meta_path = output_dir.path().join("header_only.skel.json");
+    let meta_json: Value = serde_json::from_str(&fs::read_to_string(meta_path).unwrap()).unwrap();
+    let export_types = meta_json["export_types"].as_array().unwrap();
+    assert_eq!(export_types.len(), 1);
+    assert_eq!(export_types[0]["name"].as_str().unwrap(), "selected_event");
 }

--- a/compiler/cmd/src/bpf_compiler/tests.rs
+++ b/compiler/cmd/src/bpf_compiler/tests.rs
@@ -14,6 +14,7 @@ use clap::Parser;
 use flate2::write::ZlibEncoder;
 use flate2::Compression;
 use log::debug;
+use serde_json::Value;
 use tempfile::TempDir;
 
 use crate::compile_bpf;
@@ -167,4 +168,79 @@ fn test_compress_and_pack() {
     e.write_all(&bpf_object).unwrap();
     let compressed_bytes = e.finish().unwrap();
     let _ = base64::encode(&compressed_bytes);
+}
+
+#[test]
+fn test_compile_header_only_respects_export_annotations_and_hides_dummy_symbols() {
+    let output_dir = TempDir::new().unwrap();
+    let header_path = output_dir.path().join("header_only.h");
+    fs::write(
+        &header_path,
+        r#"
+            #ifndef HEADER_ONLY_H
+            #define HEADER_ONLY_H
+
+            struct helper {
+                int ignored;
+            };
+
+            /* struct commented_out {
+                int ignored;
+            }; */
+
+            #if 0
+            struct disabled {
+                int ignored;
+            };
+            #endif
+
+            /// @export
+            struct selected_event {
+                int pid;
+            };
+
+            typedef struct helper_typedef {
+                int ignored;
+            } helper_typedef_t;
+
+            #endif
+        "#,
+    )
+    .unwrap();
+
+    let tmp_workspace = TempDir::new().unwrap();
+    init_eunomia_workspace(&tmp_workspace).unwrap();
+    let cp_args = CompileArgs::try_parse_from([
+        "ecc",
+        header_path.to_str().unwrap(),
+        "--header-only",
+        "--output-path",
+        output_dir.path().to_str().unwrap(),
+    ])
+    .unwrap();
+    let args = Options::init(cp_args, tmp_workspace).unwrap();
+    compile_bpf(&args).unwrap();
+
+    let meta_path = output_dir.path().join("header_only.skel.json");
+    let meta_json: Value = serde_json::from_str(&fs::read_to_string(meta_path).unwrap()).unwrap();
+    let export_types = meta_json["export_types"].as_array().unwrap();
+    assert_eq!(export_types.len(), 1);
+    assert_eq!(export_types[0]["name"].as_str().unwrap(), "selected_event");
+
+    if let Some(data_sections) = meta_json["bpf_skel"]["data_sections"].as_array() {
+        for data_section in data_sections {
+            let variables = data_section["variables"].as_array().unwrap();
+            assert!(variables.iter().all(|variable| {
+                !variable["name"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .starts_with("__eunomia_dummy_")
+            }));
+        }
+    }
+    if let Some(maps) = meta_json["bpf_skel"]["maps"].as_array() {
+        assert!(maps
+            .iter()
+            .all(|map| map["ident"].as_str().unwrap_or_default() != "bss"));
+    }
 }

--- a/compiler/cmd/src/config/mod.rs
+++ b/compiler/cmd/src/config/mod.rs
@@ -55,10 +55,12 @@ impl EunomiaWorkspace {
     long_about = "see https://github.com/eunomia-bpf/eunomia-bpf for more information"
 )]
 pub struct CompileArgs {
-    #[arg(help = "path of the bpf.c file to compile")]
+    #[arg(
+        help = "path of the BPF source file, or the header-only input when --header-only is used"
+    )]
     pub source_path: String,
 
-    #[arg(default_value_t = ("").to_string(), help = "path of the bpf.h header for defining event struct")]
+    #[arg(default_value_t = ("").to_string(), help = "path of the header that defines exported structs")]
     pub export_event_header: String,
 
     #[arg(
@@ -82,7 +84,7 @@ pub struct CompileArgs {
     #[arg(
         long,
         default_value_t = false,
-        help = "generate a bpf object for struct definition with header file only"
+        help = "treat SOURCE_PATH as a self-contained header translation unit and export-header input"
     )]
     pub header_only: bool,
 
@@ -243,6 +245,9 @@ pub fn get_bpf_compile_args(
         "-Wno-unknown-attributes".to_string(),
         format!("-D__TARGET_ARCH_{target_arch}"),
     ];
+    if args.compile_opts.header_only {
+        compile_args.extend(["-x".to_string(), "c".to_string()]);
+    }
     compile_args.extend(bpf_sys_include);
     compile_args.extend(get_eunomia_include_args(args)?);
     compile_args.extend(args.compile_opts.parameters.additional_cflags.clone());

--- a/compiler/cmd/src/config/options.rs
+++ b/compiler/cmd/src/config/options.rs
@@ -6,7 +6,7 @@
 use std::path::{Path, PathBuf};
 
 use super::CompileArgs;
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, bail, Result};
 use tempfile::TempDir;
 
 pub struct Options {
@@ -93,6 +93,11 @@ impl Options {
 
 fn check_compile_opts(opts: &mut CompileArgs) -> Result<()> {
     if opts.header_only {
+        if !opts.export_event_header.is_empty() && opts.export_event_header != opts.source_path {
+            bail!(
+                "--header-only uses SOURCE_PATH as the export header; do not pass a separate EXPORT_EVENT_HEADER"
+            );
+        }
         // treat header as a source file
         opts.export_event_header.clone_from(&opts.source_path);
     }

--- a/compiler/cmd/src/config/tests.rs
+++ b/compiler/cmd/src/config/tests.rs
@@ -71,6 +71,22 @@ fn test_parse_args() {
 }
 
 #[test]
+fn test_header_only_rejects_separate_export_header() {
+    let tmp_workspace = TempDir::new().unwrap();
+    init_eunomia_workspace(&tmp_workspace).unwrap();
+    let compile_opts =
+        CompileArgs::parse_from(&["ecc", "../test/client.bpf.c", "event.h", "--header-only"]);
+    let err = match Options::init(compile_opts, tmp_workspace) {
+        Ok(_) => panic!("expected --header-only validation to fail"),
+        Err(err) => err,
+    };
+
+    assert!(err
+        .to_string()
+        .contains("--header-only uses SOURCE_PATH as the export header"));
+}
+
+#[test]
 fn test_get_base_dir_include_fail() {
     get_base_dir_include_args(&PathBuf::from("/xxx/test.c")).unwrap_err();
 }

--- a/compiler/cmd/src/document_parser.rs
+++ b/compiler/cmd/src/document_parser.rs
@@ -9,11 +9,11 @@ use std::result::Result::Ok;
 
 use crate::config::get_bpf_compile_args;
 use crate::config::Options;
+use crate::helper::with_clang;
 use anyhow::anyhow;
 use anyhow::Context;
 use anyhow::Result;
 use clang::documentation::CommentChild;
-use clang::Clang;
 use clang::Entity;
 use clang::EntityKind;
 use clang::Index;
@@ -228,40 +228,34 @@ pub fn parse_source_documents(
     source_path: &str,
     bpf_skel_json: Value,
 ) -> Result<Value> {
-    // Acquire an instance of `Clang`
-    let clang = match Clang::new() {
-        Ok(clang) => clang,
-        Err(e) => {
-            return Err(anyhow!("Failed to create Clang instance: {}", e));
-        }
-    };
-    // Create a new `Index`
-    let index = Index::new(&clang, false, true);
-    let _source_path = Path::new(source_path);
-    let canonic_source_path = _source_path.canonicalize().unwrap();
-    let tu = parse_source_files(&index, args, &canonic_source_path)?;
+    with_clang(|clang| {
+        let index = Index::new(clang, false, true);
+        let _source_path = Path::new(source_path);
+        let canonic_source_path = _source_path.canonicalize().unwrap();
+        let tu = parse_source_files(&index, args, &canonic_source_path)?;
 
-    // Get the entities in this translation unit
-    let entities = tu
-        .get_entity()
-        .get_children()
-        .into_iter()
-        .filter(|e| {
-            if let Some(location) = e.get_location() {
-                if let Some(file) = location.get_file_location().file {
-                    if file.get_path() == canonic_source_path {
-                        return true;
+        // Get the entities in this translation unit
+        let entities = tu
+            .get_entity()
+            .get_children()
+            .into_iter()
+            .filter(|e| {
+                if let Some(location) = e.get_location() {
+                    if let Some(file) = location.get_file_location().file {
+                        if file.get_path() == canonic_source_path {
+                            return true;
+                        }
                     }
                 }
-            }
-            false
-        })
-        .collect::<Vec<_>>();
+                false
+            })
+            .collect::<Vec<_>>();
 
-    // resolve comments for section data and functions, maps
-    // find the entity with the same name as the names in the json skeleton
-    let new_skel_json = resolve_bpf_skel_entities(&entities, bpf_skel_json)?;
-    Ok(new_skel_json)
+        // resolve comments for section data and functions, maps
+        // find the entity with the same name as the names in the json skeleton
+        let new_skel_json = resolve_bpf_skel_entities(&entities, bpf_skel_json)?;
+        Ok(new_skel_json)
+    })
 }
 
 #[cfg(test)]

--- a/compiler/cmd/src/document_parser.rs
+++ b/compiler/cmd/src/document_parser.rs
@@ -21,6 +21,16 @@ use clang::TranslationUnit;
 use log::warn;
 use serde_json::{json, Value};
 
+fn same_source_file(actual_path: &Path, expected_path: &Path) -> bool {
+    if actual_path == expected_path {
+        return true;
+    }
+    match (actual_path.canonicalize(), expected_path.canonicalize()) {
+        (Ok(actual), Ok(expected)) => actual == expected,
+        _ => false,
+    }
+}
+
 fn parse_source_files<'a>(
     index: &'a Index<'a>,
     args: &'a Options,
@@ -230,9 +240,8 @@ pub fn parse_source_documents(
 ) -> Result<Value> {
     with_clang(|clang| {
         let index = Index::new(clang, false, true);
-        let _source_path = Path::new(source_path);
-        let canonic_source_path = _source_path.canonicalize().unwrap();
-        let tu = parse_source_files(&index, args, &canonic_source_path)?;
+        let source_path = Path::new(source_path);
+        let tu = parse_source_files(&index, args, source_path)?;
 
         // Get the entities in this translation unit
         let entities = tu
@@ -240,14 +249,10 @@ pub fn parse_source_documents(
             .get_children()
             .into_iter()
             .filter(|e| {
-                if let Some(location) = e.get_location() {
-                    if let Some(file) = location.get_file_location().file {
-                        if file.get_path() == canonic_source_path {
-                            return true;
-                        }
-                    }
-                }
-                false
+                e.get_location()
+                    .and_then(|location| location.get_file_location().file)
+                    .map(|file| same_source_file(&file.get_path(), source_path))
+                    .unwrap_or(false)
             })
             .collect::<Vec<_>>();
 

--- a/compiler/cmd/src/export_types.rs
+++ b/compiler/cmd/src/export_types.rs
@@ -3,7 +3,7 @@
 //! Copyright (c) 2023, eunomia-bpf
 //! All rights reserved.
 //!
-use std::{fs, path::Path};
+use std::{collections::HashSet, fs, path::Path};
 
 use anyhow::{anyhow, bail, Context, Result};
 use clang::{Entity, EntityKind, Index};
@@ -84,6 +84,10 @@ fn push_export_struct(candidates: &mut Vec<ExportStructCandidate>, name: String,
     } else {
         candidates.push(ExportStructCandidate { name, explicit });
     }
+}
+
+fn dummy_ptr_symbol_name(struct_name: &str) -> String {
+    format!("{DUMMY_PTR_PREFIX}{struct_name}_ptr")
 }
 
 fn collect_export_struct_candidates(args: &Options) -> Result<Vec<ExportStructCandidate>> {
@@ -173,55 +177,68 @@ pub fn add_unused_ptr_for_structs(args: &Options, file_path: impl AsRef<Path>) -
     };
 
     for struct_name in export_struct_names {
+        let dummy_symbol_name = dummy_ptr_symbol_name(&struct_name);
         content += &format!(
-            "const volatile struct {} * __eunomia_dummy_{}_ptr  __attribute__((unused));\n",
-            struct_name, struct_name
+            "const volatile struct {} * {}  __attribute__((unused));\n",
+            struct_name, dummy_symbol_name
         );
     }
     fs::write(file_path, content)?;
     Ok(())
 }
 
-pub fn strip_synthetic_bpf_skel_symbols(mut bpf_skel: Value) -> Value {
-    let mut removed_section_idents = Vec::new();
+pub fn get_synthetic_bpf_skel_symbols(args: &Options) -> Result<HashSet<String>> {
+    if args.compile_opts.export_event_header.is_empty() {
+        return Ok(HashSet::new());
+    }
+    Ok(find_all_export_structs(args)?
+        .into_iter()
+        .map(|struct_name| dummy_ptr_symbol_name(&struct_name))
+        .collect())
+}
+
+pub fn strip_synthetic_bpf_skel_symbols(
+    mut bpf_skel: Value,
+    synthetic_symbols: &HashSet<String>,
+) -> Value {
+    if synthetic_symbols.is_empty() {
+        return bpf_skel;
+    }
+
+    let mut removed_section_names = HashSet::new();
+    let mut removed_section_idents = HashSet::new();
     if let Some(data_sections) = bpf_skel["data_sections"].as_array_mut() {
         for data_section in data_sections.iter_mut() {
             if let Some(variables) = data_section["variables"].as_array_mut() {
+                let variable_count = variables.len();
                 variables.retain(|variable| {
                     variable["name"]
                         .as_str()
-                        .map(|name| !name.starts_with(DUMMY_PTR_PREFIX))
+                        .map(|name| !synthetic_symbols.contains(name))
                         .unwrap_or(true)
                 });
-            }
-            let should_remove = data_section["variables"]
-                .as_array()
-                .map(|variables| variables.is_empty())
-                .unwrap_or(false);
-            if should_remove {
-                if let Some(ident) = data_section["name"]
-                    .as_str()
-                    .and_then(|name| name.strip_prefix('.'))
-                {
-                    removed_section_idents.push(ident.to_string());
+                if variable_count != variables.len() && variables.is_empty() {
+                    if let Some(section_name) = data_section["name"].as_str() {
+                        removed_section_names.insert(section_name.to_string());
+                        if let Some(ident) = section_name.strip_prefix('.') {
+                            removed_section_idents.insert(ident.to_string());
+                        }
+                    }
                 }
             }
         }
         data_sections.retain(|data_section| {
-            !data_section["variables"]
-                .as_array()
-                .map(|variables| variables.is_empty())
-                .unwrap_or(false)
+            data_section["name"]
+                .as_str()
+                .map(|section_name| !removed_section_names.contains(section_name))
+                .unwrap_or(true)
         });
     }
     if let Some(maps) = bpf_skel["maps"].as_array_mut() {
         maps.retain(|map| {
             let mmaped = map["mmaped"].as_bool().unwrap_or(false);
             let ident = map["ident"].as_str().unwrap_or_default();
-            !(mmaped
-                && removed_section_idents
-                    .iter()
-                    .any(|removed| removed == ident))
+            !(mmaped && removed_section_idents.contains(ident))
         });
     }
     bpf_skel
@@ -229,13 +246,17 @@ pub fn strip_synthetic_bpf_skel_symbols(mut bpf_skel: Value) -> Value {
 
 #[cfg(test)]
 mod test {
+    use std::collections::HashSet;
     use std::os::unix::fs::symlink;
     use std::{fs, path::Path};
 
     use clap::Parser;
+    use serde_json::json;
     use tempfile::TempDir;
 
-    use super::{add_unused_ptr_for_structs, find_all_export_structs};
+    use super::{
+        add_unused_ptr_for_structs, find_all_export_structs, strip_synthetic_bpf_skel_symbols,
+    };
     use crate::config::{init_eunomia_workspace, CompileArgs, Options};
 
     fn create_options(
@@ -385,5 +406,55 @@ mod test {
         let structs = find_all_export_structs(&opts).unwrap();
 
         assert_eq!(structs, vec!["event"]);
+    }
+
+    #[test]
+    fn test_strip_synthetic_bpf_skel_symbols_only_removes_exact_dummy_matches() {
+        let original = json!({
+            "data_sections": [
+                {
+                    "name": ".rodata",
+                    "variables": [
+                        { "name": "__eunomia_dummy_user_setting" },
+                        { "name": "__eunomia_dummy_selected_event_ptr" },
+                        { "name": "__eunomia_dummy_selected_event_ptr_user" }
+                    ]
+                },
+                {
+                    "name": ".bss",
+                    "variables": [
+                        { "name": "kept" }
+                    ]
+                }
+            ],
+            "maps": [
+                { "ident": "rodata", "mmaped": true },
+                { "ident": "bss", "mmaped": true }
+            ]
+        });
+
+        assert_eq!(
+            strip_synthetic_bpf_skel_symbols(original.clone(), &HashSet::new()),
+            original
+        );
+
+        let stripped = strip_synthetic_bpf_skel_symbols(
+            original,
+            &HashSet::from(["__eunomia_dummy_selected_event_ptr".to_string()]),
+        );
+
+        let variables = stripped["data_sections"][0]["variables"]
+            .as_array()
+            .unwrap();
+        assert_eq!(variables.len(), 2);
+        assert_eq!(
+            variables[0]["name"].as_str().unwrap(),
+            "__eunomia_dummy_user_setting"
+        );
+        assert_eq!(
+            variables[1]["name"].as_str().unwrap(),
+            "__eunomia_dummy_selected_event_ptr_user"
+        );
+        assert_eq!(stripped["maps"].as_array().unwrap().len(), 2);
     }
 }

--- a/compiler/cmd/src/export_types.rs
+++ b/compiler/cmd/src/export_types.rs
@@ -32,18 +32,46 @@ struct ExportStructCandidate {
     explicit: bool,
 }
 
+fn same_source_file(actual_path: &Path, expected_path: &Path) -> bool {
+    if actual_path == expected_path {
+        return true;
+    }
+    match (actual_path.canonicalize(), expected_path.canonicalize()) {
+        (Ok(actual), Ok(expected)) => actual == expected,
+        _ => false,
+    }
+}
+
 fn entity_is_in_file(entity: &Entity, expected_path: &Path) -> bool {
     entity
         .get_location()
         .and_then(|location| location.get_file_location().file)
-        .map(|file| file.get_path() == expected_path)
+        .map(|file| same_source_file(&file.get_path(), expected_path))
         .unwrap_or(false)
+}
+
+fn trim_comment_marker(line: &str) -> &str {
+    let line = line.trim();
+    let line = line
+        .strip_prefix("///")
+        .or_else(|| line.strip_prefix("//!"))
+        .or_else(|| line.strip_prefix("/**"))
+        .or_else(|| line.strip_prefix("/*"))
+        .or_else(|| line.strip_prefix('*'))
+        .unwrap_or(line)
+        .trim();
+    line.strip_suffix("*/").unwrap_or(line).trim()
 }
 
 fn has_export_annotation(entity: &Entity) -> bool {
     entity
         .get_comment()
-        .map(|comment| comment.contains(EXPORT_ANNOTATION))
+        .map(|comment| {
+            comment
+                .lines()
+                .map(trim_comment_marker)
+                .any(|line| line == EXPORT_ANNOTATION)
+        })
         .unwrap_or(false)
 }
 
@@ -59,12 +87,8 @@ fn push_export_struct(candidates: &mut Vec<ExportStructCandidate>, name: String,
 }
 
 fn collect_export_struct_candidates(args: &Options) -> Result<Vec<ExportStructCandidate>> {
-    let source_path = Path::new(&args.compile_opts.source_path)
-        .canonicalize()
-        .with_context(|| anyhow!("Failed to canonicalize source path"))?;
-    let export_header_path = Path::new(&args.compile_opts.export_event_header)
-        .canonicalize()
-        .with_context(|| anyhow!("Failed to canonicalize export header path"))?;
+    let source_path = Path::new(&args.compile_opts.source_path).to_path_buf();
+    let export_header_path = Path::new(&args.compile_opts.export_event_header).to_path_buf();
 
     with_clang(|clang| {
         let index = Index::new(clang, false, true);
@@ -205,6 +229,7 @@ pub fn strip_synthetic_bpf_skel_symbols(mut bpf_skel: Value) -> Value {
 
 #[cfg(test)]
 mod test {
+    use std::os::unix::fs::symlink;
     use std::{fs, path::Path};
 
     use clap::Parser;
@@ -275,6 +300,25 @@ mod test {
     }
 
     #[test]
+    fn test_find_all_export_structs_ignores_export_mentions_in_prose() {
+        let temp_dir = TempDir::new().unwrap();
+        let header_path = temp_dir.path().join("event.h");
+        let source_path = temp_dir.path().join("test.bpf.c");
+        let test_event = r#"
+            /// This helper mentions @export in prose but is not annotated.
+            struct helper { int x; };
+            struct event { int x; };
+        "#;
+        fs::write(&header_path, test_event).unwrap();
+        fs::write(&source_path, "#include \"event.h\"\n").unwrap();
+
+        let opts = create_options(&source_path, Some(&header_path), false);
+        let structs = find_all_export_structs(&opts).unwrap();
+
+        assert_eq!(structs, vec!["helper", "event"]);
+    }
+
+    #[test]
     fn test_add_unused_ptr_for_structs() {
         let temp_dir = TempDir::new().unwrap();
         let header_path = temp_dir.path().join("event.h");
@@ -313,5 +357,33 @@ mod test {
         let structs = find_all_export_structs(&opts).unwrap();
 
         assert_eq!(structs, vec!["event4"]);
+    }
+
+    #[test]
+    fn test_find_all_export_structs_header_only_keeps_symlink_include_root() {
+        let temp_dir = TempDir::new().unwrap();
+        let real_dir = temp_dir.path().join("real");
+        let symlink_dir = temp_dir.path().join("link");
+        fs::create_dir_all(&real_dir).unwrap();
+        fs::create_dir_all(&symlink_dir).unwrap();
+
+        let real_header_path = real_dir.join("event.h");
+        let symlink_header_path = symlink_dir.join("event.h");
+        fs::write(
+            &real_header_path,
+            r#"
+                #include "shared.h"
+                /// @export
+                struct event { shared_int_t x; };
+            "#,
+        )
+        .unwrap();
+        fs::write(symlink_dir.join("shared.h"), "typedef int shared_int_t;\n").unwrap();
+        symlink(&real_header_path, &symlink_header_path).unwrap();
+
+        let opts = create_options(&symlink_header_path, None, true);
+        let structs = find_all_export_structs(&opts).unwrap();
+
+        assert_eq!(structs, vec!["event"]);
     }
 }

--- a/compiler/cmd/src/export_types.rs
+++ b/compiler/cmd/src/export_types.rs
@@ -5,9 +5,15 @@
 //!
 use std::{fs, path::Path};
 
-use crate::config::*;
-use anyhow::{bail, Result};
-use regex::Regex;
+use anyhow::{anyhow, bail, Context, Result};
+use clang::{Entity, EntityKind, Index};
+use serde_json::Value;
+
+use crate::{
+    config::{get_bpf_compile_args, Options},
+    helper::with_clang,
+};
+
 const _EXPORT_C_TEMPLATE: &str = r#"
 // do not use this file: auto generated
 #include "vmlinux.h"
@@ -17,24 +23,121 @@ const _EXPORT_C_TEMPLATE: &str = r#"
 
 "#;
 
-const REGEX_STRUCT_PATTERN: &str = r#"struct\s+(\w+)\s*\{"#;
+const DUMMY_PTR_PREFIX: &str = "__eunomia_dummy_";
+const EXPORT_ANNOTATION: &str = "@export";
 
-// find all structs in event header
-pub fn find_all_export_structs(args: &CompileArgs) -> Result<Vec<String>> {
-    let mut export_structs: Vec<String> = Vec::new();
-    let export_struct_header = fs::read_to_string(&args.export_event_header)?;
-    let re = Regex::new(REGEX_STRUCT_PATTERN).unwrap();
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ExportStructCandidate {
+    name: String,
+    explicit: bool,
+}
 
-    for cap in re.captures_iter(&export_struct_header) {
-        let struct_name = &cap[1];
-        export_structs.push(struct_name.to_string());
+fn entity_is_in_file(entity: &Entity, expected_path: &Path) -> bool {
+    entity
+        .get_location()
+        .and_then(|location| location.get_file_location().file)
+        .map(|file| file.get_path() == expected_path)
+        .unwrap_or(false)
+}
+
+fn has_export_annotation(entity: &Entity) -> bool {
+    entity
+        .get_comment()
+        .map(|comment| comment.contains(EXPORT_ANNOTATION))
+        .unwrap_or(false)
+}
+
+fn push_export_struct(candidates: &mut Vec<ExportStructCandidate>, name: String, explicit: bool) {
+    if let Some(existing) = candidates
+        .iter_mut()
+        .find(|candidate| candidate.name == name)
+    {
+        existing.explicit |= explicit;
+    } else {
+        candidates.push(ExportStructCandidate { name, explicit });
     }
-    Ok(export_structs)
+}
+
+fn collect_export_struct_candidates(args: &Options) -> Result<Vec<ExportStructCandidate>> {
+    let source_path = Path::new(&args.compile_opts.source_path)
+        .canonicalize()
+        .with_context(|| anyhow!("Failed to canonicalize source path"))?;
+    let export_header_path = Path::new(&args.compile_opts.export_event_header)
+        .canonicalize()
+        .with_context(|| anyhow!("Failed to canonicalize export header path"))?;
+
+    with_clang(|clang| {
+        let index = Index::new(clang, false, true);
+        let compile_args = get_bpf_compile_args(args, &source_path)?;
+        let tu = index
+            .parser(&source_path)
+            .arguments(&compile_args)
+            .parse()
+            .with_context(|| anyhow!("Failed to build translation unit for export types"))?;
+        let mut candidates = Vec::new();
+
+        for entity in tu.get_entity().get_children() {
+            if !entity_is_in_file(&entity, &export_header_path) {
+                continue;
+            }
+            match entity.get_kind() {
+                EntityKind::StructDecl if entity.is_definition() => {
+                    if let Some(name) = entity.get_name() {
+                        push_export_struct(&mut candidates, name, has_export_annotation(&entity));
+                    }
+                }
+                EntityKind::TypedefDecl => {
+                    let Some(struct_decl) = entity
+                        .get_typedef_underlying_type()
+                        .and_then(|ty| ty.get_declaration())
+                    else {
+                        continue;
+                    };
+                    if struct_decl.get_kind() != EntityKind::StructDecl
+                        || !struct_decl.is_definition()
+                        || !entity_is_in_file(&struct_decl, &export_header_path)
+                    {
+                        continue;
+                    }
+                    let Some(name) = struct_decl.get_name() else {
+                        continue;
+                    };
+                    push_export_struct(
+                        &mut candidates,
+                        name,
+                        has_export_annotation(&entity) || has_export_annotation(&struct_decl),
+                    );
+                }
+                _ => {}
+            }
+        }
+
+        Ok(candidates)
+    })
+}
+
+/// Select named struct definitions from the designated export header.
+/// If any struct is annotated with `@export`, only annotated structs are exported.
+/// Otherwise all named struct definitions are exported for backward compatibility.
+pub fn find_all_export_structs(args: &Options) -> Result<Vec<String>> {
+    let candidates = collect_export_struct_candidates(args)?;
+    if candidates.iter().any(|candidate| candidate.explicit) {
+        Ok(candidates
+            .into_iter()
+            .filter(|candidate| candidate.explicit)
+            .map(|candidate| candidate.name)
+            .collect())
+    } else {
+        Ok(candidates
+            .into_iter()
+            .map(|candidate| candidate.name)
+            .collect())
+    }
 }
 
 /// add unused_ptr_for_structs to preserve BTF info
 /// optional: add  __attribute__((preserve_access_index)) for structs to preserve BTF info
-pub fn add_unused_ptr_for_structs(args: &CompileArgs, file_path: impl AsRef<Path>) -> Result<()> {
+pub fn add_unused_ptr_for_structs(args: &Options, file_path: impl AsRef<Path>) -> Result<()> {
     let file_path = file_path.as_ref();
     let export_struct_names = find_all_export_structs(args)?;
     let content = fs::read_to_string(file_path);
@@ -55,52 +158,160 @@ pub fn add_unused_ptr_for_structs(args: &CompileArgs, file_path: impl AsRef<Path
     Ok(())
 }
 
+pub fn strip_synthetic_bpf_skel_symbols(mut bpf_skel: Value) -> Value {
+    let mut removed_section_idents = Vec::new();
+    if let Some(data_sections) = bpf_skel["data_sections"].as_array_mut() {
+        for data_section in data_sections.iter_mut() {
+            if let Some(variables) = data_section["variables"].as_array_mut() {
+                variables.retain(|variable| {
+                    variable["name"]
+                        .as_str()
+                        .map(|name| !name.starts_with(DUMMY_PTR_PREFIX))
+                        .unwrap_or(true)
+                });
+            }
+            let should_remove = data_section["variables"]
+                .as_array()
+                .map(|variables| variables.is_empty())
+                .unwrap_or(false);
+            if should_remove {
+                if let Some(ident) = data_section["name"]
+                    .as_str()
+                    .and_then(|name| name.strip_prefix('.'))
+                {
+                    removed_section_idents.push(ident.to_string());
+                }
+            }
+        }
+        data_sections.retain(|data_section| {
+            !data_section["variables"]
+                .as_array()
+                .map(|variables| variables.is_empty())
+                .unwrap_or(false)
+        });
+    }
+    if let Some(maps) = bpf_skel["maps"].as_array_mut() {
+        maps.retain(|map| {
+            let mmaped = map["mmaped"].as_bool().unwrap_or(false);
+            let ident = map["ident"].as_str().unwrap_or_default();
+            !(mmaped
+                && removed_section_idents
+                    .iter()
+                    .any(|removed| removed == ident))
+        });
+    }
+    bpf_skel
+}
+
 #[cfg(test)]
 mod test {
-    use std::{fs, path::PathBuf};
+    use std::{fs, path::Path};
 
     use clap::Parser;
+    use tempfile::TempDir;
 
-    use crate::{
-        config::CompileArgs,
-        export_types::{add_unused_ptr_for_structs, find_all_export_structs},
-    };
+    use super::{add_unused_ptr_for_structs, find_all_export_structs};
+    use crate::config::{init_eunomia_workspace, CompileArgs, Options};
+
+    fn create_options(
+        source_path: &Path,
+        export_header_path: Option<&Path>,
+        header_only: bool,
+    ) -> Options {
+        let tmp_workspace = TempDir::new().unwrap();
+        init_eunomia_workspace(&tmp_workspace).unwrap();
+
+        let mut argv = vec!["ecc".to_string(), source_path.to_str().unwrap().to_string()];
+        if let Some(export_header_path) = export_header_path {
+            argv.push(export_header_path.to_str().unwrap().to_string());
+        }
+        if header_only {
+            argv.push("--header-only".to_string());
+        }
+
+        Options::init(CompileArgs::try_parse_from(argv).unwrap(), tmp_workspace).unwrap()
+    }
 
     #[test]
-    fn test_match_struct() {
-        let tmp_file = "/tmp/tmp_test_event.h";
-        let arg: CompileArgs = CompileArgs::try_parse_from(["ecc", "_", tmp_file]).unwrap();
+    fn test_find_all_export_structs_ignores_comments_and_if0() {
+        let temp_dir = TempDir::new().unwrap();
+        let header_path = temp_dir.path().join("event.h");
+        let source_path = temp_dir.path().join("test.bpf.c");
         let test_event = r#"
-            struct eventqwrd3 { int x };
-            struct event2 { int x };
-            typedef struct event3 { int x } event3_t;
+            struct eventqwrd3 { int x; };
+            /* struct commented_out { int x; }; */
+            #if 0
+            struct disabled { int x; };
+            #endif
+            typedef struct event3 { int x; } event3_t;
         "#;
-        fs::write(tmp_file, test_event).unwrap();
-        let structs = find_all_export_structs(&arg).unwrap();
-        assert_eq!(structs.len(), 3);
-        assert_eq!(structs[0], "eventqwrd3");
-        assert_eq!(structs[1], "event2");
-        assert_eq!(structs[2], "event3");
-        fs::remove_file(tmp_file).unwrap();
+        fs::write(&header_path, test_event).unwrap();
+        fs::write(&source_path, "#include \"event.h\"\n").unwrap();
+
+        let opts = create_options(&source_path, Some(&header_path), false);
+        let structs = find_all_export_structs(&opts).unwrap();
+
+        assert_eq!(structs, vec!["eventqwrd3", "event3"]);
+    }
+
+    #[test]
+    fn test_find_all_export_structs_prefers_export_annotations() {
+        let temp_dir = TempDir::new().unwrap();
+        let header_path = temp_dir.path().join("event.h");
+        let source_path = temp_dir.path().join("test.bpf.c");
+        let test_event = r#"
+            struct helper { int x; };
+            /// @export
+            typedef struct event3 { int x; } event3_t;
+            struct event2 { int x; };
+        "#;
+        fs::write(&header_path, test_event).unwrap();
+        fs::write(&source_path, "#include \"event.h\"\n").unwrap();
+
+        let opts = create_options(&source_path, Some(&header_path), false);
+        let structs = find_all_export_structs(&opts).unwrap();
+
+        assert_eq!(structs, vec!["event3"]);
     }
 
     #[test]
     fn test_add_unused_ptr_for_structs() {
-        let tmp_file = "tmp_test_event.h";
-        let tmp_source_file = PathBuf::from("tmp_test_event.c");
-        let arg = CompileArgs::try_parse_from(["ecc", "_", tmp_file]).unwrap();
+        let temp_dir = TempDir::new().unwrap();
+        let header_path = temp_dir.path().join("event.h");
+        let source_path = temp_dir.path().join("test.bpf.c");
+        let tmp_source_file = temp_dir.path().join("tmp_test_event.c");
         let test_event = r#"
-            struct eventqwrd3 { int x };
-            struct event2 { int x };
-            typedef struct event3 { int x } event3_t;
+            struct helper { int x; };
+            /// @export
+            struct event2 { int x; };
+            /// @export
+            typedef struct event3 { int x; } event3_t;
         "#;
-        let test_source_content_res = "const volatile struct eventqwrd3 * __eunomia_dummy_eventqwrd3_ptr  __attribute__((unused));\nconst volatile struct event2 * __eunomia_dummy_event2_ptr  __attribute__((unused));\nconst volatile struct event3 * __eunomia_dummy_event3_ptr  __attribute__((unused));\n";
-        fs::write(tmp_file, test_event).unwrap();
+        let test_source_content_res = "const volatile struct event2 * __eunomia_dummy_event2_ptr  __attribute__((unused));\nconst volatile struct event3 * __eunomia_dummy_event3_ptr  __attribute__((unused));\n";
+        fs::write(&header_path, test_event).unwrap();
+        fs::write(&source_path, "#include \"event.h\"\n").unwrap();
         fs::write(&tmp_source_file, "").unwrap();
-        add_unused_ptr_for_structs(&arg, &tmp_source_file).unwrap();
+
+        let opts = create_options(&source_path, Some(&header_path), false);
+        add_unused_ptr_for_structs(&opts, &tmp_source_file).unwrap();
+
         let content = fs::read_to_string(&tmp_source_file).unwrap();
         assert_eq!(test_source_content_res, content);
-        fs::remove_file(tmp_file).unwrap();
-        fs::remove_file(&tmp_source_file).unwrap();
+    }
+
+    #[test]
+    fn test_find_all_export_structs_header_only_uses_source_header() {
+        let temp_dir = TempDir::new().unwrap();
+        let header_path = temp_dir.path().join("event.h");
+        let test_event = r#"
+            /// @export
+            struct event4 { int x; };
+        "#;
+        fs::write(&header_path, test_event).unwrap();
+
+        let opts = create_options(&header_path, None, true);
+        let structs = find_all_export_structs(&opts).unwrap();
+
+        assert_eq!(structs, vec!["event4"]);
     }
 }

--- a/compiler/cmd/src/helper.rs
+++ b/compiler/cmd/src/helper.rs
@@ -4,11 +4,14 @@
 //! All rights reserved.
 //!
 use anyhow::{anyhow, Context, Result};
+use clang::Clang;
 use log::debug;
 use std::env::var;
 use std::path::PathBuf;
+use std::sync::{Mutex, OnceLock};
 /// Search the data directory of eunomia from environment variables
 const EUNOMIA_HOME_ENV: &str = "EUNOMIA_HOME";
+static LIBCLANG_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 pub fn get_eunomia_data_dir() -> Result<PathBuf> {
     if let Ok(e) = var(EUNOMIA_HOME_ENV) {
         return Ok(e.into());
@@ -63,6 +66,20 @@ pub fn get_target_arch() -> String {
     debug!("Target architecture: {arch}");
 
     arch.to_string()
+}
+
+pub fn with_clang<T, F>(f: F) -> Result<T>
+where
+    F: FnOnce(&Clang) -> Result<T>,
+{
+    let _guard = LIBCLANG_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    clang_sys::load()
+        .map_err(|e| anyhow!("Failed to load libclang dynamically at runtime: {}", e))?;
+    let clang = Clang::new().map_err(|e| anyhow!("Failed to create Clang instance: {}", e))?;
+    f(&clang)
 }
 
 #[macro_export]


### PR DESCRIPTION
Fixes #386

## Summary
- replace regex-based export detection with AST-driven export discovery while keeping backward-compatible fallback behavior
- strip only the exact synthetic export-preservation symbols from generated metadata
- harden header-only and symlinked input handling, and add targeted regression coverage

## Testing
- cargo test --manifest-path compiler/cmd/Cargo.toml test_strip_synthetic_bpf_skel_symbols_only_removes_exact_dummy_matches -- --nocapture
- cargo test --manifest-path compiler/cmd/Cargo.toml test_compile_header_only_ -- --nocapture
- cargo test --manifest-path compiler/cmd/Cargo.toml export_types::test:: -- --nocapture
