### PR TITLE
Harden standalone runtime packaging and release rollback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: ecli bpf-loader-rs eunomia-exporter help install-deps clean all
+.PHONY: ecli bpf-loader-rs eunomia-exporter help install-deps clean all release
 .DEFAULT_GOAL := all
 all: bpf-loader-rs ecli ## Build all binaries
 
@@ -33,7 +33,7 @@ help:
 
 install-deps: ## install deps
 	apt update
-	apt-get install libcurl4-openssl-dev libelf-dev clang llvm cmake zlib1g-dev libzstd-dev liblzma-dev
+	apt-get install libcurl4-openssl-dev libelf-dev clang llvm cmake zlib1g-dev libzstd-dev liblzma-dev pkg-config
 
 ecli: ## build the command line tool for eunomia-bpf
 	make -C ecli build
@@ -56,8 +56,11 @@ XDG_DATA_HOME ?= ${HOME}/.local/share
 EUNOMIA_HOME ?= $(XDG_DATA_HOME)/eunomia
 
 release:
-	make -C ecli install
-	make -C compiler install
-	cp -R $(EUNOMIA_HOME) eunomia
+	@set -eu; \
+	staging_root="$$(mktemp -d)"; \
+	trap 'rm -rf "$$staging_root" eunomia' EXIT; \
+	stage_home="$$staging_root/eunomia"; \
+	$(MAKE) -C ecli install EUNOMIA_HOME="$$stage_home"; \
+	$(MAKE) -C compiler install EUNOMIA_HOME="$$stage_home"; \
+	cp -R "$$stage_home" eunomia; \
 	tar -czvf eunomia.tar.gz eunomia
-	rm -rf eunomia

--- a/Makefile
+++ b/Makefile
@@ -58,9 +58,13 @@ EUNOMIA_HOME ?= $(XDG_DATA_HOME)/eunomia
 release:
 	@set -eu; \
 	staging_root="$$(mktemp -d)"; \
-	trap 'rm -rf "$$staging_root" eunomia' EXIT; \
+	release_root="$$(mktemp -d ./.eunomia.release.XXXXXX)"; \
+	trap 'rm -rf "$$staging_root" "$$release_root"' EXIT; \
 	stage_home="$$staging_root/eunomia"; \
 	$(MAKE) -C ecli install EUNOMIA_HOME="$$stage_home"; \
 	$(MAKE) -C compiler install EUNOMIA_HOME="$$stage_home"; \
-	cp -R "$$stage_home" eunomia; \
+	cp -R "$$stage_home" "$$release_root/eunomia"; \
+	rm -rf eunomia; \
+	mv "$$release_root/eunomia" eunomia; \
+	rmdir "$$release_root"; \
 	tar -czvf eunomia.tar.gz eunomia

--- a/Makefile
+++ b/Makefile
@@ -60,18 +60,34 @@ release:
 	staging_root="$$(mktemp -d)"; \
 	release_root="$$(mktemp -d ./.eunomia.release.XXXXXX)"; \
 	previous_root=""; \
+	previous_archive=""; \
+	runtime_promoted=0; \
 	release_live=0; \
 	cleanup() { \
 		status=$$?; \
 		set +e; \
-		if [ $$status -ne 0 ] && [ "$$release_live" -eq 0 ] && [ -n "$$previous_root" ] && [ -e "$$previous_root" ]; then \
-			rm -rf eunomia; \
-			mv "$$previous_root" eunomia; \
-			previous_root=""; \
+		if [ $$status -ne 0 ] && [ "$$release_live" -eq 0 ]; then \
+			if [ "$$runtime_promoted" -eq 1 ] && [ -e eunomia ]; then \
+				rm -rf eunomia; \
+			fi; \
+			if [ -n "$$previous_root" ] && [ -e "$$previous_root" ]; then \
+				mv "$$previous_root" eunomia; \
+				previous_root=""; \
+			fi; \
+			if [ -e eunomia.tar.gz ] && [ -n "$$previous_archive" ] && [ -e "$$previous_archive" ]; then \
+				rm -f eunomia.tar.gz; \
+			fi; \
+			if [ -n "$$previous_archive" ] && [ -e "$$previous_archive" ]; then \
+				mv "$$previous_archive" eunomia.tar.gz; \
+				previous_archive=""; \
+			fi; \
 		fi; \
 		rm -rf "$$staging_root" "$$release_root"; \
-		if [ $$status -ne 0 ] && [ "$$release_live" -eq 1 ] && [ -n "$$previous_root" ] && [ -e "$$previous_root" ]; then \
-			printf '%s\n' "release installed, but backup cleanup failed; inspect $$previous_root" >&2; \
+		if [ $$status -ne 0 ] && [ "$$release_live" -eq 1 ] && [ -n "$$previous_archive" ] && [ -e "$$previous_archive" ]; then \
+			if rm -f "$$previous_archive"; then previous_archive=""; fi; \
+		fi; \
+		if [ $$status -ne 0 ] && [ "$$release_live" -eq 1 ] && { [ -n "$$previous_root" ] || [ -n "$$previous_archive" ]; }; then \
+			printf '%s\n' "release installed, but backup cleanup failed; inspect lingering .eunomia.previous* artifacts" >&2; \
 		fi; \
 		exit $$status; \
 	}; \
@@ -81,8 +97,11 @@ release:
 	$(MAKE) -C compiler install EUNOMIA_HOME="$$stage_home"; \
 	cp -R "$$stage_home" "$$release_root/eunomia"; \
 	tar -czvf "$$release_root/eunomia.tar.gz" -C "$$release_root" eunomia; \
-	mv "$$release_root/eunomia.tar.gz" eunomia.tar.gz; \
 	if [ -e eunomia ]; then previous_root="$$(mktemp -d ./.eunomia.previous.XXXXXX)"; rmdir "$$previous_root"; mv eunomia "$$previous_root"; fi; \
 	mv "$$release_root/eunomia" eunomia; \
+	runtime_promoted=1; \
+	if [ -e eunomia.tar.gz ]; then previous_archive="$$(mktemp ./.eunomia.previous.tar.gz.XXXXXX)"; mv eunomia.tar.gz "$$previous_archive"; fi; \
+	mv "$$release_root/eunomia.tar.gz" eunomia.tar.gz; \
 	release_live=1; \
-	if [ -n "$$previous_root" ]; then rm -rf "$$previous_root"; previous_root=""; fi
+	if [ -n "$$previous_root" ]; then rm -rf "$$previous_root"; previous_root=""; fi; \
+	if [ -n "$$previous_archive" ]; then rm -f "$$previous_archive"; previous_archive=""; fi

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ help:
 
 install-deps: ## install deps
 	apt update
-	apt-get install libcurl4-openssl-dev libelf-dev clang llvm cmake zlib1g-dev
+	apt-get install libcurl4-openssl-dev libelf-dev clang llvm cmake zlib1g-dev libzstd-dev liblzma-dev
 
 ecli: ## build the command line tool for eunomia-bpf
 	make -C ecli build

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ eunomia-exporter: ## build the exporter for custom metric
 	cd eunomia-exporter && cargo build --release
 
 XDG_DATA_HOME ?= ${HOME}/.local/share
-EUNOMIA_HOME := $(XDG_DATA_HOME)/eunomia
+EUNOMIA_HOME ?= $(XDG_DATA_HOME)/eunomia
 
 release:
 	make -C ecli install

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ release:
 	if [ -e eunomia ]; then previous_root="$$(mktemp -d ./.eunomia.previous.XXXXXX)"; rmdir "$$previous_root"; mv eunomia "$$previous_root"; fi; \
 	mv "$$release_root/eunomia" eunomia; \
 	runtime_promoted=1; \
-	if [ -e eunomia.tar.gz ]; then previous_archive="$$(mktemp ./.eunomia.previous.tar.gz.XXXXXX)"; mv eunomia.tar.gz "$$previous_archive"; fi; \
+	if [ -e eunomia.tar.gz ]; then archive_backup_path="$$(mktemp ./.eunomia.previous.tar.gz.XXXXXX)"; rm -f "$$archive_backup_path"; mv eunomia.tar.gz "$$archive_backup_path"; previous_archive="$$archive_backup_path"; fi; \
 	mv "$$release_root/eunomia.tar.gz" eunomia.tar.gz; \
 	release_live=1; \
 	if [ -n "$$previous_root" ]; then rm -rf "$$previous_root"; previous_root=""; fi; \

--- a/Makefile
+++ b/Makefile
@@ -59,12 +59,14 @@ release:
 	@set -eu; \
 	staging_root="$$(mktemp -d)"; \
 	release_root="$$(mktemp -d ./.eunomia.release.XXXXXX)"; \
-	trap 'rm -rf "$$staging_root" "$$release_root"' EXIT; \
+	previous_root=""; \
+	trap 'status=$$?; if [ $$status -ne 0 ] && [ -n "$$previous_root" ]; then rm -rf eunomia; mv "$$previous_root" eunomia; fi; rm -rf "$$staging_root" "$$release_root"; exit $$status' EXIT; \
 	stage_home="$$staging_root/eunomia"; \
 	$(MAKE) -C ecli install EUNOMIA_HOME="$$stage_home"; \
 	$(MAKE) -C compiler install EUNOMIA_HOME="$$stage_home"; \
 	cp -R "$$stage_home" "$$release_root/eunomia"; \
-	rm -rf eunomia; \
+	tar -czvf "$$release_root/eunomia.tar.gz" -C "$$release_root" eunomia; \
+	mv "$$release_root/eunomia.tar.gz" eunomia.tar.gz; \
+	if [ -e eunomia ]; then previous_root="$$release_root/eunomia.previous"; mv eunomia "$$previous_root"; fi; \
 	mv "$$release_root/eunomia" eunomia; \
-	rmdir "$$release_root"; \
-	tar -czvf eunomia.tar.gz eunomia
+	if [ -n "$$previous_root" ]; then rm -rf "$$previous_root"; previous_root=""; fi

--- a/Makefile
+++ b/Makefile
@@ -60,13 +60,29 @@ release:
 	staging_root="$$(mktemp -d)"; \
 	release_root="$$(mktemp -d ./.eunomia.release.XXXXXX)"; \
 	previous_root=""; \
-	trap 'status=$$?; if [ $$status -ne 0 ] && [ -n "$$previous_root" ]; then rm -rf eunomia; mv "$$previous_root" eunomia; fi; rm -rf "$$staging_root" "$$release_root"; exit $$status' EXIT; \
+	release_live=0; \
+	cleanup() { \
+		status=$$?; \
+		set +e; \
+		if [ $$status -ne 0 ] && [ "$$release_live" -eq 0 ] && [ -n "$$previous_root" ] && [ -e "$$previous_root" ]; then \
+			rm -rf eunomia; \
+			mv "$$previous_root" eunomia; \
+			previous_root=""; \
+		fi; \
+		rm -rf "$$staging_root" "$$release_root"; \
+		if [ $$status -ne 0 ] && [ "$$release_live" -eq 1 ] && [ -n "$$previous_root" ] && [ -e "$$previous_root" ]; then \
+			printf '%s\n' "release installed, but backup cleanup failed; inspect $$previous_root" >&2; \
+		fi; \
+		exit $$status; \
+	}; \
+	trap cleanup EXIT; \
 	stage_home="$$staging_root/eunomia"; \
 	$(MAKE) -C ecli install EUNOMIA_HOME="$$stage_home"; \
 	$(MAKE) -C compiler install EUNOMIA_HOME="$$stage_home"; \
 	cp -R "$$stage_home" "$$release_root/eunomia"; \
 	tar -czvf "$$release_root/eunomia.tar.gz" -C "$$release_root" eunomia; \
 	mv "$$release_root/eunomia.tar.gz" eunomia.tar.gz; \
-	if [ -e eunomia ]; then previous_root="$$release_root/eunomia.previous"; mv eunomia "$$previous_root"; fi; \
+	if [ -e eunomia ]; then previous_root="$$(mktemp -d ./.eunomia.previous.XXXXXX)"; rmdir "$$previous_root"; mv eunomia "$$previous_root"; fi; \
 	mv "$$release_root/eunomia" eunomia; \
+	release_live=1; \
 	if [ -n "$$previous_root" ]; then rm -rf "$$previous_root"; previous_root=""; fi

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The legacy remote HTTP mode (`ecli client` / `ecli-server`) has been removed fro
     ....
     ```
 
-- Install the `ecc` compiler-toolchain for compiling eBPF kernel code to a `config` file or `Wasm` module(`clang`, `llvm`, and `libclang` should be installed for compiling):
+- Install the `ecc` compiler-toolchain for compiling eBPF kernel code to a `config` file or `Wasm` module(`clang`, `llvm`, `libclang`, and `pkg-config` should be installed for compiling):
 
     ```console
     $ wget https://github.com/eunomia-bpf/eunomia-bpf/releases/latest/download/ecc && chmod +x ./ecc

--- a/README_zh.md
+++ b/README_zh.md
@@ -85,7 +85,7 @@ $ sudo ./ecli run ghcr.io/eunomia-bpf/execve:latest # 从 OCI 仓库运行一个
     ....
     ```
 
-- 安装`ecc`编译器工具链，用于将eBPF内核代码编译为`config`文件或`Wasm`模块（为了编译，需要安装`clang`、`llvm`和`libclang`）：
+- 安装`ecc`编译器工具链，用于将eBPF内核代码编译为`config`文件或`Wasm`模块（为了编译，需要安装`clang`、`llvm`、`libclang`和`pkg-config`）：
 
     ```console
     $ wget https://github.com/eunomia-bpf/eunomia-bpf/releases/latest/download/ecc && chmod +x ./ecc

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -138,7 +138,7 @@ endif
 .PHONY: install-deps
 install-deps:
 	sudo apt-get update
-	sudo apt-get -y install clang libelf1 libelf-dev zlib1g-dev libzstd-dev liblzma-dev cmake llvm libclang-dev
+	sudo apt-get -y install clang libelf1 libelf-dev zlib1g-dev libzstd-dev liblzma-dev cmake llvm libclang-dev pkg-config
 
 # delete failed targets
 .DELETE_ON_ERROR:

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -6,12 +6,13 @@ LLVM_STRIP ?= llvm-strip
 BPFTOOL_SRC := $(abspath ../third_party/bpftool)
 BPFTOOL := $(BPFTOOL_SRC)/src/bpftool
 ECC := cmd/target/release/ecc-rs
-LIBEUNOMIA := ../bpf-loader-rs/target/release/libeunomia.a
-LIBEUNOMIA_LINKFLAGS := ../bpf-loader-rs/target/release/libeunomia.a.linkflags
+LIBEUNOMIA_TARGET_DIR := ../bpf-loader-rs/target/eunomia-standalone-runtime
+LIBEUNOMIA := $(LIBEUNOMIA_TARGET_DIR)/release/libeunomia.a
+LIBEUNOMIA_LINKFLAGS := $(LIBEUNOMIA_TARGET_DIR)/release/libeunomia.a.linkflags
 WORKSPACE_ECC := workspace/bin/ecc-rs
 WORKSPACE_LIBEUNOMIA := workspace/libeunomia.a
 WORKSPACE_LIBEUNOMIA_LINKFLAGS := workspace/libeunomia.a.linkflags
-STANDALONE_RUNTIME_SOURCES := $(shell find ../bpf-loader-rs/bpf-loader-c-wrapper ../bpf-loader-rs/bpf-loader-lib -type f) ../bpf-loader-rs/Cargo.toml ../bpf-loader-rs/Cargo.lock
+STANDALONE_RUNTIME_SOURCES := $(shell find ../bpf-loader-rs/bpf-loader-c-wrapper/src ../bpf-loader-rs/bpf-loader-lib/src -type f -name '*.rs') ../bpf-loader-rs/bpf-loader-c-wrapper/Cargo.toml ../bpf-loader-rs/bpf-loader-lib/Cargo.toml ../bpf-loader-rs/Cargo.toml ../bpf-loader-rs/Cargo.lock
 ARCH := $(shell uname -m | sed 's/x86_64/x86/' | sed 's/aarch64/arm64/' | sed 's/ppc64le/powerpc/' | sed 's/mips.*/mips/' | sed 's/riscv64/riscv/')
 VMLINUX := ../third_party/vmlinux/$(ARCH)/vmlinux.h
 # Use our own libbpf API headers and Linux UAPI headers distributed with
@@ -69,7 +70,8 @@ $(BPFTOOL):
 	$(MAKE) -C $(BPFTOOL_SRC)/src
 
 $(WORKSPACE_LIBEUNOMIA) $(WORKSPACE_LIBEUNOMIA_LINKFLAGS): $(STANDALONE_RUNTIME_SOURCES)
-	( cargo rustc --manifest-path ../bpf-loader-rs/Cargo.toml -p bpf-loader-c-wrapper --release -- --print=native-static-libs 2>&1 | awk -F 'native-static-libs: ' '/native-static-libs:/ { print $$2 }'; pkg-config --static --libs libelf zlib 2>/dev/null || true ) | awk 'BEGIN { first = 1 } { for (i = 1; i <= NF; i++) { if ($$i != "-lgcc_s" && !seen[$$i]++) { printf "%s%s", first ? "" : " ", $$i; first = 0 } } } END { print "" }' > $(LIBEUNOMIA_LINKFLAGS)
+	mkdir -p $(LIBEUNOMIA_TARGET_DIR)/release
+	( cargo rustc --manifest-path ../bpf-loader-rs/Cargo.toml -p bpf-loader-c-wrapper --target-dir $(LIBEUNOMIA_TARGET_DIR) --release -- --print=native-static-libs 2>&1 | awk -F 'native-static-libs: ' '/native-static-libs:/ { print $$2 }'; pkg-config --static --libs libelf zlib 2>/dev/null || true ) | awk '{ for (i = 1; i <= NF; i++) { if ($$i != "-lgcc_s") { printf "%s ", $$i } } } END { print "" }' > $(LIBEUNOMIA_LINKFLAGS)
 	test -s $(LIBEUNOMIA_LINKFLAGS)
 	test -f $(LIBEUNOMIA)
 	mkdir -p workspace

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -69,7 +69,7 @@ $(BPFTOOL):
 	$(MAKE) -C $(BPFTOOL_SRC)/src
 
 $(WORKSPACE_LIBEUNOMIA) $(WORKSPACE_LIBEUNOMIA_LINKFLAGS): $(STANDALONE_RUNTIME_SOURCES)
-	cargo rustc --manifest-path ../bpf-loader-rs/Cargo.toml -p bpf-loader-c-wrapper --release -- --print=native-static-libs 2>&1 | awk -F 'native-static-libs: ' '/native-static-libs:/ { print $$2 }' | awk 'BEGIN { first = 1 } { for (i = 1; i <= NF; i++) { if ($$i != "-lgcc_s") { printf "%s%s", first ? "" : " ", $$i; first = 0 } } } END { print "" }' > $(LIBEUNOMIA_LINKFLAGS)
+	( cargo rustc --manifest-path ../bpf-loader-rs/Cargo.toml -p bpf-loader-c-wrapper --release -- --print=native-static-libs 2>&1 | awk -F 'native-static-libs: ' '/native-static-libs:/ { print $$2 }'; pkg-config --static --libs libelf zlib 2>/dev/null || true ) | awk 'BEGIN { first = 1 } { for (i = 1; i <= NF; i++) { if ($$i != "-lgcc_s" && !seen[$$i]++) { printf "%s%s", first ? "" : " ", $$i; first = 0 } } } END { print "" }' > $(LIBEUNOMIA_LINKFLAGS)
 	test -s $(LIBEUNOMIA_LINKFLAGS)
 	test -f $(LIBEUNOMIA)
 	mkdir -p workspace
@@ -90,7 +90,7 @@ XDG_DATA_HOME ?= ${HOME}/.local/share
 EUNOMIA_HOME := $(XDG_DATA_HOME)/eunomia
 
 install: all
-	rm -rf $(EUNOMIA_HOME) && mkdir -p $(EUNOMIA_HOME) && cp -r workspace/* $(EUNOMIA_HOME)
+	mkdir -p $(EUNOMIA_HOME) && cp -r workspace/. $(EUNOMIA_HOME)/
 .PHONY: test
 test:
 	cargo install clippy-sarif sarif-fmt grcov

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -138,7 +138,7 @@ endif
 .PHONY: install-deps
 install-deps:
 	sudo apt-get update
-	sudo apt-get -y install clang libelf1 libelf-dev zlib1g-dev cmake llvm libclang-dev
+	sudo apt-get -y install clang libelf1 libelf-dev zlib1g-dev libzstd-dev liblzma-dev cmake llvm libclang-dev
 
 # delete failed targets
 .DELETE_ON_ERROR:

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -70,13 +70,25 @@ $(BPFTOOL):
 	$(MAKE) -C $(BPFTOOL_SRC)/src
 
 $(WORKSPACE_LIBEUNOMIA) $(WORKSPACE_LIBEUNOMIA_LINKFLAGS): $(STANDALONE_RUNTIME_SOURCES)
-	mkdir -p $(LIBEUNOMIA_TARGET_DIR)/release
-	( cargo rustc --manifest-path ../bpf-loader-rs/Cargo.toml -p bpf-loader-c-wrapper --target-dir $(LIBEUNOMIA_TARGET_DIR) --release -- --print=native-static-libs 2>&1 | awk -F 'native-static-libs: ' '/native-static-libs:/ { print $$2 }'; pkg-config --static --libs libelf zlib 2>/dev/null || true ) | awk '{ for (i = 1; i <= NF; i++) { if ($$i != "-lgcc_s") { printf "%s ", $$i } } } END { print "" }' > $(LIBEUNOMIA_LINKFLAGS)
-	test -s $(LIBEUNOMIA_LINKFLAGS)
-	test -f $(LIBEUNOMIA)
-	mkdir -p workspace
-	cp $(LIBEUNOMIA) $(WORKSPACE_LIBEUNOMIA)
-	cp $(LIBEUNOMIA_LINKFLAGS) $(WORKSPACE_LIBEUNOMIA_LINKFLAGS)
+	set -eu; \
+	mkdir -p $(LIBEUNOMIA_TARGET_DIR)/release; \
+	tmp_output="$$(mktemp)"; \
+	tmp_linkflags="$$(mktemp)"; \
+	trap 'rm -f "$$tmp_output" "$$tmp_linkflags"' EXIT; \
+	if ! cargo rustc --manifest-path ../bpf-loader-rs/Cargo.toml -p bpf-loader-c-wrapper --target-dir $(LIBEUNOMIA_TARGET_DIR) --release -- --print=native-static-libs >"$$tmp_output" 2>&1; then \
+		cat "$$tmp_output"; \
+		exit 1; \
+	fi; \
+	{ \
+		awk -F 'native-static-libs: ' '/native-static-libs:/ { print $$2 }' "$$tmp_output"; \
+		pkg-config --static --libs libelf zlib 2>/dev/null || true; \
+	} | awk '{ for (i = 1; i <= NF; i++) { if ($$i != "-lgcc_s") { printf "%s ", $$i } } } END { print "" }' > "$$tmp_linkflags"; \
+	test -s "$$tmp_linkflags"; \
+	test -f $(LIBEUNOMIA); \
+	cp "$$tmp_linkflags" $(LIBEUNOMIA_LINKFLAGS); \
+	mkdir -p workspace; \
+	cp $(LIBEUNOMIA) $(WORKSPACE_LIBEUNOMIA); \
+	cp "$$tmp_linkflags" $(WORKSPACE_LIBEUNOMIA_LINKFLAGS)
 
 $(ECC): $(BPFTOOL)
 	cd cmd && cargo build --release

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -89,7 +89,7 @@ $(WORKSPACE_ECC): $(ECC)
 	cp $(ECC) $(WORKSPACE_ECC)
 
 XDG_DATA_HOME ?= ${HOME}/.local/share
-EUNOMIA_HOME := $(XDG_DATA_HOME)/eunomia
+EUNOMIA_HOME ?= $(XDG_DATA_HOME)/eunomia
 
 install: all
 	mkdir -p $(EUNOMIA_HOME) && cp -r workspace/. $(EUNOMIA_HOME)/

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -8,6 +8,10 @@ BPFTOOL := $(BPFTOOL_SRC)/src/bpftool
 ECC := cmd/target/release/ecc-rs
 LIBEUNOMIA := ../bpf-loader-rs/target/release/libeunomia.a
 LIBEUNOMIA_LINKFLAGS := ../bpf-loader-rs/target/release/libeunomia.a.linkflags
+WORKSPACE_ECC := workspace/bin/ecc-rs
+WORKSPACE_LIBEUNOMIA := workspace/libeunomia.a
+WORKSPACE_LIBEUNOMIA_LINKFLAGS := workspace/libeunomia.a.linkflags
+STANDALONE_RUNTIME_SOURCES := $(shell find ../bpf-loader-rs/bpf-loader-c-wrapper ../bpf-loader-rs/bpf-loader-lib -type f) ../bpf-loader-rs/Cargo.toml ../bpf-loader-rs/Cargo.lock
 ARCH := $(shell uname -m | sed 's/x86_64/x86/' | sed 's/aarch64/arm64/' | sed 's/ppc64le/powerpc/' | sed 's/mips.*/mips/' | sed 's/riscv64/riscv/')
 VMLINUX := ../third_party/vmlinux/$(ARCH)/vmlinux.h
 # Use our own libbpf API headers and Linux UAPI headers distributed with
@@ -44,8 +48,8 @@ else
 	MAKEFLAGS += --no-print-directory
 endif
 
-.PHONY: all install $(ECC)
-all: $(ECC)
+.PHONY: all install
+all: $(WORKSPACE_ECC) $(WORKSPACE_LIBEUNOMIA) $(WORKSPACE_LIBEUNOMIA_LINKFLAGS)
 
 wasi-sdk-16.0-linux.tar.gz:
 	wget https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-16/wasi-sdk-16.0-linux.tar.gz
@@ -54,7 +58,7 @@ wasi-sdk-16.0-linux.tar.gz:
 .PHONY: clean
 clean:
 	$(call msg,CLEAN)
-	$(Q)rm -rf $(OUTPUT) $(APPS) *.o
+	$(Q)rm -rf $(OUTPUT) $(APPS) *.o workspace
 	cd cmd && cargo clean
 
 $(OUTPUT) $(OUTPUT)/libbpf:
@@ -64,25 +68,28 @@ $(OUTPUT) $(OUTPUT)/libbpf:
 $(BPFTOOL):
 	$(MAKE) -C $(BPFTOOL_SRC)/src
 
-$(LIBEUNOMIA_LINKFLAGS):
+$(WORKSPACE_LIBEUNOMIA) $(WORKSPACE_LIBEUNOMIA_LINKFLAGS): $(STANDALONE_RUNTIME_SOURCES)
 	cargo rustc --manifest-path ../bpf-loader-rs/Cargo.toml -p bpf-loader-c-wrapper --release -- --print=native-static-libs 2>&1 | awk -F 'native-static-libs: ' '/native-static-libs:/ { print $$2 }' | awk 'BEGIN { first = 1 } { for (i = 1; i <= NF; i++) { if ($$i != "-lgcc_s") { printf "%s%s", first ? "" : " ", $$i; first = 0 } } } END { print "" }' > $(LIBEUNOMIA_LINKFLAGS)
 	test -s $(LIBEUNOMIA_LINKFLAGS)
 	test -f $(LIBEUNOMIA)
+	mkdir -p workspace
+	cp $(LIBEUNOMIA) $(WORKSPACE_LIBEUNOMIA)
+	cp $(LIBEUNOMIA_LINKFLAGS) $(WORKSPACE_LIBEUNOMIA_LINKFLAGS)
 
-$(ECC): $(BPFTOOL) $(LIBEUNOMIA_LINKFLAGS)
+$(ECC): $(BPFTOOL)
 	cd cmd && cargo build --release
 	cargo install cargo-out-dir
 	cd cmd && cargo build # Run a debug build to create the workspace directory 
 	# cd cmd && cp -r `cargo-out-dir`/workspace ..
+
+$(WORKSPACE_ECC): $(ECC)
 	mkdir -p workspace/bin
-	cp $(ECC) workspace/bin/ecc-rs
-	cp $(LIBEUNOMIA) workspace/libeunomia.a
-	cp $(LIBEUNOMIA_LINKFLAGS) workspace/libeunomia.a.linkflags
+	cp $(ECC) $(WORKSPACE_ECC)
 
 XDG_DATA_HOME ?= ${HOME}/.local/share
 EUNOMIA_HOME := $(XDG_DATA_HOME)/eunomia
 
-install:
+install: all
 	rm -rf $(EUNOMIA_HOME) && mkdir -p $(EUNOMIA_HOME) && cp -r workspace/* $(EUNOMIA_HOME)
 .PHONY: test
 test:

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -6,6 +6,8 @@ LLVM_STRIP ?= llvm-strip
 BPFTOOL_SRC := $(abspath ../third_party/bpftool)
 BPFTOOL := $(BPFTOOL_SRC)/src/bpftool
 ECC := cmd/target/release/ecc-rs
+LIBEUNOMIA := ../bpf-loader-rs/target/release/libeunomia.a
+LIBEUNOMIA_LINKFLAGS := ../bpf-loader-rs/target/release/libeunomia.a.linkflags
 ARCH := $(shell uname -m | sed 's/x86_64/x86/' | sed 's/aarch64/arm64/' | sed 's/ppc64le/powerpc/' | sed 's/mips.*/mips/' | sed 's/riscv64/riscv/')
 VMLINUX := ../third_party/vmlinux/$(ARCH)/vmlinux.h
 # Use our own libbpf API headers and Linux UAPI headers distributed with
@@ -62,13 +64,20 @@ $(OUTPUT) $(OUTPUT)/libbpf:
 $(BPFTOOL):
 	$(MAKE) -C $(BPFTOOL_SRC)/src
 
-$(ECC): $(BPFTOOL)
+$(LIBEUNOMIA_LINKFLAGS):
+	cargo rustc --manifest-path ../bpf-loader-rs/Cargo.toml -p bpf-loader-c-wrapper --release -- --print=native-static-libs 2>&1 | awk -F 'native-static-libs: ' '/native-static-libs:/ { print $$2 }' | awk 'BEGIN { first = 1 } { for (i = 1; i <= NF; i++) { if ($$i != "-lgcc_s") { printf "%s%s", first ? "" : " ", $$i; first = 0 } } } END { print "" }' > $(LIBEUNOMIA_LINKFLAGS)
+	test -s $(LIBEUNOMIA_LINKFLAGS)
+	test -f $(LIBEUNOMIA)
+
+$(ECC): $(BPFTOOL) $(LIBEUNOMIA_LINKFLAGS)
 	cd cmd && cargo build --release
 	cargo install cargo-out-dir
 	cd cmd && cargo build # Run a debug build to create the workspace directory 
 	# cd cmd && cp -r `cargo-out-dir`/workspace ..
 	mkdir -p workspace/bin
 	cp $(ECC) workspace/bin/ecc-rs
+	cp $(LIBEUNOMIA) workspace/libeunomia.a
+	cp $(LIBEUNOMIA_LINKFLAGS) workspace/libeunomia.a.linkflags
 
 XDG_DATA_HOME ?= ${HOME}/.local/share
 EUNOMIA_HOME := $(XDG_DATA_HOME)/eunomia

--- a/compiler/README.md
+++ b/compiler/README.md
@@ -23,6 +23,8 @@ chmod +x ecc
 sudo mv ecc /usr/local/bin/
 ```
 
+The raw GitHub release binary currently does **not** bundle the `libeunomia.a` standalone sidecar, so `--standalone` is not supported from that install path yet.
+
 Install from source with the standalone runtime staged into `EUNOMIA_HOME`:
 ```bash
 cd compiler
@@ -134,7 +136,7 @@ ecc program.bpf.c --standalone -o mytool
 
 Produces a self-contained executable with embedded eBPF program and runner.
 
-`--standalone` now links against the normal `bpf-loader-c-wrapper` static archive plus its native link flags. A compiler install created with `make install` stages `libeunomia.a` and `libeunomia.a.linkflags` automatically. If you run `ecc` directly from a checkout, it will build that archive from `bpf-loader-rs/` on first use when needed.
+`--standalone` now links against the normal `bpf-loader-c-wrapper` static archive plus its native link flags. A compiler install created with `make install` stages `libeunomia.a` and `libeunomia.a.linkflags` automatically, and the Nix package installs the same sidecar into `$out/lib`. If you run `ecc` directly from a checkout, it will build that archive from `bpf-loader-rs/` on first use when needed.
 
 ### WebAssembly Header
 ```bash

--- a/compiler/README.md
+++ b/compiler/README.md
@@ -34,6 +34,8 @@ make install
 EUNOMIA_HOME=/tmp/custom make install
 ```
 
+When `EUNOMIA_HOME` is set, `ecc --standalone` checks that runtime root before packaged sidecars or checkout-local fallbacks.
+
 Or use Docker:
 ```bash
 # For x86_64
@@ -140,7 +142,9 @@ ecc program.bpf.c --standalone -o dist
 
 Produces a self-contained executable with embedded eBPF program and runner.
 
-`--standalone` now links against the normal `bpf-loader-c-wrapper` static archive plus its native link flags. A compiler install created with `make install` stages `libeunomia.a` and `libeunomia.a.linkflags` automatically, and the Nix package installs the same sidecar into `$out/lib`. If you run `ecc` directly from a checkout, it will build that archive from `bpf-loader-rs/` on first use when needed.
+`--standalone` now links against the normal `bpf-loader-c-wrapper` static archive plus its native link flags. A compiler install created with `make install` stages `libeunomia.a` and `libeunomia.a.linkflags` automatically, and the Nix package installs the same sidecar into `$out/lib`. Runtime lookup checks `EUNOMIA_STANDALONE_LIB` first, then `EUNOMIA_HOME` when set. If neither override resolves a sidecar, `ecc` falls back to its packaged or checkout-local runtime discovery.
+
+On Linux source installs, keep the native static link dependencies for those flags available too: `libzstd-dev` and `liblzma-dev` on Debian/Ubuntu, or `libzstd-devel` and `xz-devel` on Fedora.
 
 ### WebAssembly Header
 ```bash
@@ -303,13 +307,13 @@ fs::write("package.json", serde_json::to_string(&package)?)?;
 
 **Ubuntu/Debian:**
 ```bash
-apt install clang libelf1 libelf-dev zlib1g-dev llvm
+apt install clang libelf1 libelf-dev zlib1g-dev libzstd-dev liblzma-dev llvm
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
 **CentOS/Fedora:**
 ```bash
-dnf install clang elfutils-libelf elfutils-libelf-devel zlib-devel
+dnf install clang elfutils-libelf elfutils-libelf-devel zlib-devel libzstd-devel xz-devel
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 

--- a/compiler/README.md
+++ b/compiler/README.md
@@ -25,7 +25,7 @@ sudo mv ecc /usr/local/bin/
 
 The raw GitHub release binary currently does **not** bundle the `libeunomia.a` standalone sidecar, so `--standalone` is not supported from that install path yet.
 
-Install from source with the standalone runtime staged into your user `EUNOMIA_HOME` / `XDG_DATA_HOME`:
+Install from source with the standalone runtime staged into the same user data directory that `ecc` looks up at runtime (`$EUNOMIA_HOME`, or `$XDG_DATA_HOME/eunomia`, or `$HOME/.local/share/eunomia`):
 ```bash
 cd compiler
 make install

--- a/compiler/README.md
+++ b/compiler/README.md
@@ -25,10 +25,10 @@ sudo mv ecc /usr/local/bin/
 
 The raw GitHub release binary currently does **not** bundle the `libeunomia.a` standalone sidecar, so `--standalone` is not supported from that install path yet.
 
-Install from source with the standalone runtime staged into `EUNOMIA_HOME`:
+Install from source with the standalone runtime staged into your user `EUNOMIA_HOME` / `XDG_DATA_HOME`:
 ```bash
 cd compiler
-sudo make install
+make install
 ```
 
 Or use Docker:
@@ -128,10 +128,11 @@ Same content as JSON but in YAML format.
 
 ### Standalone Executable
 ```bash
-ecc program.bpf.c --standalone -o mytool
-# → mytool (single executable)
+mkdir -p dist
+ecc program.bpf.c --standalone -o dist
+# → dist/program.out
 
-./mytool  # Run directly
+./dist/program.out  # Run directly
 ```
 
 Produces a self-contained executable with embedded eBPF program and runner.

--- a/compiler/README.md
+++ b/compiler/README.md
@@ -307,7 +307,7 @@ fs::write("package.json", serde_json::to_string(&package)?)?;
 
 **Ubuntu/Debian:**
 ```bash
-apt install clang libelf1 libelf-dev zlib1g-dev libzstd-dev liblzma-dev llvm
+apt install clang libelf1 libelf-dev zlib1g-dev libzstd-dev liblzma-dev llvm pkg-config
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
@@ -316,6 +316,8 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 dnf install clang elfutils-libelf elfutils-libelf-devel zlib-devel libzstd-devel xz-devel
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
+
+Install the `pkg-config` executable as provided by your distro as well; `ecc --standalone` now uses it when resolving static runtime link flags.
 
 ### Build Steps
 

--- a/compiler/README.md
+++ b/compiler/README.md
@@ -23,6 +23,12 @@ chmod +x ecc
 sudo mv ecc /usr/local/bin/
 ```
 
+Install from source with the standalone runtime staged into `EUNOMIA_HOME`:
+```bash
+cd compiler
+sudo make install
+```
+
 Or use Docker:
 ```bash
 # For x86_64
@@ -127,6 +133,8 @@ ecc program.bpf.c --standalone -o mytool
 ```
 
 Produces a self-contained executable with embedded eBPF program and runner.
+
+`--standalone` now links against the normal `bpf-loader-c-wrapper` static archive plus its native link flags. A compiler install created with `make install` stages `libeunomia.a` and `libeunomia.a.linkflags` automatically. If you run `ecc` directly from a checkout, it will build that archive from `bpf-loader-rs/` on first use when needed.
 
 ### WebAssembly Header
 ```bash

--- a/compiler/README.md
+++ b/compiler/README.md
@@ -25,10 +25,13 @@ sudo mv ecc /usr/local/bin/
 
 The raw GitHub release binary currently does **not** bundle the `libeunomia.a` standalone sidecar, so `--standalone` is not supported from that install path yet.
 
-Install from source with the standalone runtime staged into the same user data directory that `ecc` looks up at runtime (`$EUNOMIA_HOME`, or `$XDG_DATA_HOME/eunomia`, or `$HOME/.local/share/eunomia`):
+Install from source with the standalone runtime staged into the same user data directory that `ecc` looks up at runtime. The source install target honors `EUNOMIA_HOME` first, then falls back to `$XDG_DATA_HOME/eunomia`, then `$HOME/.local/share/eunomia`:
 ```bash
 cd compiler
 make install
+
+# Optional: stage into a custom runtime root
+EUNOMIA_HOME=/tmp/custom make install
 ```
 
 Or use Docker:
@@ -324,7 +327,10 @@ git submodule update --init --recursive --remote
 make
 
 # Install
-sudo make install
+make install
+
+# Optional: preserve a custom runtime root
+EUNOMIA_HOME=/tmp/custom make install
 
 # Verify
 ecc -h

--- a/compiler/cmd/src/bpf_compiler/standalone.rs
+++ b/compiler/cmd/src/bpf_compiler/standalone.rs
@@ -4,7 +4,9 @@
 //! All rights reserved.
 //!
 use std::{
-    env, fs,
+    env,
+    ffi::OsStr,
+    fs,
     io::ErrorKind,
     path::{Path, PathBuf},
     process::Command,
@@ -17,6 +19,7 @@ use log::{debug, info};
 const STANDALONE_RUNTIME_ENV: &str = "EUNOMIA_STANDALONE_LIB";
 const EUNOMIA_HOME_ENV: &str = "EUNOMIA_HOME";
 const CHECKOUT_RUNTIME_TARGET_DIR: &str = "bpf-loader-rs/target/eunomia-standalone-runtime";
+const BIN_DIR_NAME: &str = "bin";
 const DEFAULT_NATIVE_LINK_ARGS: &[&str] = &[
     "-lelf",
     "-lz",
@@ -242,20 +245,42 @@ fn checkout_roots() -> Vec<PathBuf> {
     roots
 }
 
-fn installed_runtime_candidates() -> Vec<PathBuf> {
-    let mut candidates = Vec::new();
+fn add_current_exe_runtime_candidates(candidates: &mut Vec<PathBuf>, current_exe: &Path) {
+    let Some(current_exe_dir) = current_exe.parent() else {
+        return;
+    };
 
-    if let Ok(current_exe) = env::current_exe() {
-        if let Some(current_exe_dir) = current_exe.parent() {
-            for ancestor in current_exe_dir.ancestors() {
-                add_install_layout_candidates(&mut candidates, ancestor);
-            }
+    add_install_layout_candidates(candidates, current_exe_dir);
+
+    if current_exe_dir.file_name() == Some(OsStr::new(BIN_DIR_NAME)) {
+        if let Some(install_root) = current_exe_dir.parent() {
+            add_install_layout_candidates(candidates, install_root);
         }
     }
+}
 
-    if let Ok(eunomia_home) = get_eunomia_data_dir() {
-        add_install_layout_candidates(&mut candidates, &eunomia_home);
+fn installed_runtime_candidates_for(
+    current_exe: Option<&Path>,
+    eunomia_home: Option<&Path>,
+) -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+
+    if let Some(current_exe) = current_exe {
+        add_current_exe_runtime_candidates(&mut candidates, current_exe);
     }
+
+    if let Some(eunomia_home) = eunomia_home {
+        add_install_layout_candidates(&mut candidates, eunomia_home);
+    }
+
+    candidates
+}
+
+fn installed_runtime_candidates() -> Vec<PathBuf> {
+    let current_exe = env::current_exe().ok();
+    let eunomia_home = get_eunomia_data_dir().ok();
+    let candidates =
+        installed_runtime_candidates_for(current_exe.as_deref(), eunomia_home.as_deref());
 
     debug!(
         "Installed standalone runtime search paths: {:?}",
@@ -416,10 +441,10 @@ pub(crate) fn build_standalone_executable(opts: &Options) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::{
-        checkout_runtime_build_dir, find_checkout_root, link_flags_path_for,
-        merge_native_link_args, normalize_native_link_args, parse_native_link_args,
-        resolve_standalone_runtime, select_runtime_resolution, RuntimeSelection, EUNOMIA_HOME_ENV,
-        STANDALONE_RUNTIME_ENV,
+        checkout_runtime_build_dir, find_checkout_root, installed_runtime_candidates_for,
+        link_flags_path_for, merge_native_link_args, normalize_native_link_args,
+        parse_native_link_args, resolve_standalone_runtime, select_runtime_resolution,
+        RuntimeSelection, EUNOMIA_HOME_ENV, STANDALONE_RUNTIME_ENV,
     };
     use std::{
         ffi::OsString,
@@ -570,6 +595,42 @@ mod tests {
                 panic!("installed runtime should win before checkout fallback")
             }
         }
+    }
+
+    #[test]
+    fn test_installed_runtime_candidates_only_consider_current_bin_root_and_eunomia_home() {
+        let candidates = installed_runtime_candidates_for(
+            Some(Path::new("/opt/eunomia/bin/ecc-rs")),
+            Some(Path::new("/home/test/.local/share/eunomia")),
+        );
+
+        assert_eq!(
+            candidates,
+            vec![
+                PathBuf::from("/opt/eunomia/bin/libeunomia.a"),
+                PathBuf::from("/opt/eunomia/bin/lib/libeunomia.a"),
+                PathBuf::from("/opt/eunomia/libeunomia.a"),
+                PathBuf::from("/opt/eunomia/lib/libeunomia.a"),
+                PathBuf::from("/home/test/.local/share/eunomia/libeunomia.a"),
+                PathBuf::from("/home/test/.local/share/eunomia/lib/libeunomia.a"),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_installed_runtime_candidates_do_not_walk_past_non_bin_executable_dirs() {
+        let candidates = installed_runtime_candidates_for(
+            Some(Path::new("/tmp/build/target/release/ecc-rs")),
+            None,
+        );
+
+        assert_eq!(
+            candidates,
+            vec![
+                PathBuf::from("/tmp/build/target/release/libeunomia.a"),
+                PathBuf::from("/tmp/build/target/release/lib/libeunomia.a"),
+            ]
+        );
     }
 
     #[test]

--- a/compiler/cmd/src/bpf_compiler/standalone.rs
+++ b/compiler/cmd/src/bpf_compiler/standalone.rs
@@ -15,6 +15,7 @@ use anyhow::{anyhow, bail, Context, Result};
 use log::{debug, info};
 
 const STANDALONE_RUNTIME_ENV: &str = "EUNOMIA_STANDALONE_LIB";
+const EUNOMIA_HOME_ENV: &str = "EUNOMIA_HOME";
 const CHECKOUT_RUNTIME_TARGET_DIR: &str = "bpf-loader-rs/target/eunomia-standalone-runtime";
 const DEFAULT_NATIVE_LINK_ARGS: &[&str] = &[
     "-lelf",
@@ -216,6 +217,17 @@ fn installed_runtime_candidates() -> Vec<PathBuf> {
     candidates
 }
 
+fn eunomia_home_runtime_candidates() -> Option<Vec<PathBuf>> {
+    let eunomia_home = env::var_os(EUNOMIA_HOME_ENV)?;
+    let mut candidates = Vec::new();
+    add_install_layout_candidates(&mut candidates, Path::new(&eunomia_home));
+    debug!(
+        "EUNOMIA_HOME standalone runtime search paths: {:?}",
+        candidates
+    );
+    Some(candidates)
+}
+
 fn checkout_runtime_build_dir(checkout_root: &Path) -> PathBuf {
     checkout_root.join(CHECKOUT_RUNTIME_TARGET_DIR)
 }
@@ -293,6 +305,15 @@ fn resolve_standalone_runtime() -> Result<StandaloneRuntime> {
         return standalone_runtime_from_library_path(explicit_path);
     }
 
+    if let Some(eunomia_home_candidates) = eunomia_home_runtime_candidates() {
+        if let Some(path) = eunomia_home_candidates
+            .into_iter()
+            .find(|path| path.exists())
+        {
+            return standalone_runtime_from_library_path(path);
+        }
+    }
+
     let mut build_error = None;
     for checkout_root in checkout_roots() {
         match build_runtime_from_checkout(&checkout_root) {
@@ -367,9 +388,64 @@ mod tests {
     use super::{
         checkout_runtime_build_dir, find_checkout_root, link_flags_path_for,
         merge_native_link_args, normalize_native_link_args, parse_native_link_args,
+        resolve_standalone_runtime, EUNOMIA_HOME_ENV, STANDALONE_RUNTIME_ENV,
     };
-    use std::{fs, path::Path};
+    use std::{
+        ffi::OsString,
+        fs,
+        path::{Path, PathBuf},
+        sync::{Mutex, OnceLock},
+    };
     use tempfile::TempDir;
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    struct EnvGuard {
+        saved: Vec<(&'static str, Option<OsString>)>,
+    }
+
+    impl EnvGuard {
+        fn capture(keys: &[&'static str]) -> Self {
+            Self {
+                saved: keys
+                    .iter()
+                    .map(|key| (*key, std::env::var_os(key)))
+                    .collect(),
+            }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (key, value) in &self.saved {
+                match value {
+                    Some(value) => std::env::set_var(key, value),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+    }
+
+    struct CwdGuard {
+        saved: PathBuf,
+    }
+
+    impl CwdGuard {
+        fn capture() -> Self {
+            Self {
+                saved: std::env::current_dir().unwrap(),
+            }
+        }
+    }
+
+    impl Drop for CwdGuard {
+        fn drop(&mut self) {
+            std::env::set_current_dir(&self.saved).unwrap();
+        }
+    }
 
     #[test]
     fn test_parse_native_link_args() {
@@ -437,5 +513,44 @@ mod tests {
     fn test_link_flags_path_for() {
         let path = link_flags_path_for(Path::new("/tmp/libeunomia.a"));
         assert_eq!(path, Path::new("/tmp/libeunomia.a.linkflags"));
+    }
+
+    #[test]
+    fn test_resolve_standalone_runtime_prefers_eunomia_home_over_checkout_builds() {
+        let _lock = env_lock().lock().unwrap();
+        let _env = EnvGuard::capture(&[
+            EUNOMIA_HOME_ENV,
+            STANDALONE_RUNTIME_ENV,
+            "XDG_DATA_HOME",
+            "HOME",
+        ]);
+        let _cwd = CwdGuard::capture();
+        let temp_dir = TempDir::new().unwrap();
+        let eunomia_home = temp_dir.path().join("custom-eunomia-home");
+        let library_path = eunomia_home.join("libeunomia.a");
+        let repo_root = temp_dir.path().join("repo-root");
+        let checkout_dir = repo_root.join("compiler/cmd/src");
+
+        fs::create_dir_all(&eunomia_home).unwrap();
+        fs::write(&library_path, "").unwrap();
+        fs::write(link_flags_path_for(&library_path), "-lelf").unwrap();
+
+        fs::create_dir_all(repo_root.join("bpf-loader-rs")).unwrap();
+        fs::create_dir_all(&checkout_dir).unwrap();
+        fs::write(repo_root.join("bpf-loader-rs/Cargo.toml"), "[workspace]\n").unwrap();
+        fs::write(
+            repo_root.join("compiler/cmd/Cargo.toml"),
+            "[package]\nname = \"dummy\"\nversion = \"0.0.0\"\n",
+        )
+        .unwrap();
+
+        std::env::set_var(EUNOMIA_HOME_ENV, &eunomia_home);
+        std::env::remove_var(STANDALONE_RUNTIME_ENV);
+        std::env::remove_var("XDG_DATA_HOME");
+        std::env::remove_var("HOME");
+        std::env::set_current_dir(&checkout_dir).unwrap();
+
+        let runtime = resolve_standalone_runtime().unwrap();
+        assert_eq!(runtime.library_path, library_path);
     }
 }

--- a/compiler/cmd/src/bpf_compiler/standalone.rs
+++ b/compiler/cmd/src/bpf_compiler/standalone.rs
@@ -33,6 +33,11 @@ struct StandaloneRuntime {
     native_link_args: Vec<String>,
 }
 
+enum RuntimeSelection {
+    ExistingLibrary(PathBuf),
+    CheckoutRoots(Vec<PathBuf>),
+}
+
 fn num_to_hex(v: u8) -> char {
     match v {
         0..=9 => (48 + v) as char,
@@ -164,6 +169,49 @@ fn standalone_runtime_from_library_path(library_path: PathBuf) -> Result<Standal
     })
 }
 
+fn first_existing_runtime_candidate<I>(candidates: I) -> Option<PathBuf>
+where
+    I: IntoIterator<Item = PathBuf>,
+{
+    candidates.into_iter().find(|path| path.exists())
+}
+
+fn select_runtime_resolution(
+    explicit_path: Option<PathBuf>,
+    eunomia_home_candidates: Option<Vec<PathBuf>>,
+    installed_candidates: Vec<PathBuf>,
+    checkout_roots: Vec<PathBuf>,
+) -> Result<RuntimeSelection> {
+    if let Some(explicit_path) = explicit_path {
+        if !explicit_path.exists() {
+            bail!(
+                "`{}` points to `{}`, but that file does not exist",
+                STANDALONE_RUNTIME_ENV,
+                explicit_path.display()
+            );
+        }
+        return Ok(RuntimeSelection::ExistingLibrary(explicit_path));
+    }
+
+    if let Some(path) =
+        first_existing_runtime_candidate(eunomia_home_candidates.into_iter().flatten())
+    {
+        return Ok(RuntimeSelection::ExistingLibrary(path));
+    }
+
+    if let Some(path) = first_existing_runtime_candidate(installed_candidates) {
+        return Ok(RuntimeSelection::ExistingLibrary(path));
+    }
+
+    if !checkout_roots.is_empty() {
+        return Ok(RuntimeSelection::CheckoutRoots(checkout_roots));
+    }
+
+    bail!(
+        "Failed to locate `libeunomia.a` for `--standalone`. Install `ecc` via `make -C compiler install`, or build the runtime with `cargo rustc --manifest-path bpf-loader-rs/Cargo.toml -p bpf-loader-c-wrapper --release -- --print=native-static-libs`."
+    );
+}
+
 fn find_checkout_root(start: &Path) -> Option<PathBuf> {
     for candidate in start.ancestors() {
         if candidate.join("bpf-loader-rs/Cargo.toml").is_file()
@@ -293,54 +341,36 @@ fn build_runtime_from_checkout(checkout_root: &Path) -> Result<StandaloneRuntime
 }
 
 fn resolve_standalone_runtime() -> Result<StandaloneRuntime> {
-    if let Ok(explicit_path) = env::var(STANDALONE_RUNTIME_ENV) {
-        let explicit_path = PathBuf::from(explicit_path);
-        if !explicit_path.exists() {
-            bail!(
-                "`{}` points to `{}`, but that file does not exist",
-                STANDALONE_RUNTIME_ENV,
-                explicit_path.display()
-            );
-        }
-        return standalone_runtime_from_library_path(explicit_path);
-    }
-
-    if let Some(eunomia_home_candidates) = eunomia_home_runtime_candidates() {
-        if let Some(path) = eunomia_home_candidates
-            .into_iter()
-            .find(|path| path.exists())
-        {
-            return standalone_runtime_from_library_path(path);
-        }
-    }
-
-    let mut build_error = None;
-    for checkout_root in checkout_roots() {
-        match build_runtime_from_checkout(&checkout_root) {
-            Ok(runtime) => return Ok(runtime),
-            Err(err) => {
-                debug!(
-                    "Failed to build checkout standalone runtime from {}: {}",
-                    checkout_root.display(),
-                    err
-                );
-                build_error = Some(err);
+    match select_runtime_resolution(
+        env::var(STANDALONE_RUNTIME_ENV).ok().map(PathBuf::from),
+        eunomia_home_runtime_candidates(),
+        installed_runtime_candidates(),
+        checkout_roots(),
+    )? {
+        RuntimeSelection::ExistingLibrary(path) => standalone_runtime_from_library_path(path),
+        RuntimeSelection::CheckoutRoots(checkout_roots) => {
+            let mut build_error = None;
+            for checkout_root in checkout_roots {
+                match build_runtime_from_checkout(&checkout_root) {
+                    Ok(runtime) => return Ok(runtime),
+                    Err(err) => {
+                        debug!(
+                            "Failed to build checkout standalone runtime from {}: {}",
+                            checkout_root.display(),
+                            err
+                        );
+                        build_error = Some(err);
+                    }
+                }
             }
+
+            if let Some(err) = build_error {
+                return Err(err);
+            }
+
+            unreachable!("runtime selection should only return checkout roots when present");
         }
     }
-
-    let installed_candidates = installed_runtime_candidates();
-    if let Some(path) = installed_candidates.into_iter().find(|path| path.exists()) {
-        return standalone_runtime_from_library_path(path);
-    }
-
-    if let Some(err) = build_error {
-        return Err(err);
-    }
-
-    bail!(
-        "Failed to locate `libeunomia.a` for `--standalone`. Install `ecc` via `make -C compiler install`, or build the runtime with `cargo rustc --manifest-path bpf-loader-rs/Cargo.toml -p bpf-loader-c-wrapper --release -- --print=native-static-libs`."
-    );
 }
 
 pub(crate) fn build_standalone_executable(opts: &Options) -> Result<()> {
@@ -388,7 +418,8 @@ mod tests {
     use super::{
         checkout_runtime_build_dir, find_checkout_root, link_flags_path_for,
         merge_native_link_args, normalize_native_link_args, parse_native_link_args,
-        resolve_standalone_runtime, EUNOMIA_HOME_ENV, STANDALONE_RUNTIME_ENV,
+        resolve_standalone_runtime, select_runtime_resolution, RuntimeSelection, EUNOMIA_HOME_ENV,
+        STANDALONE_RUNTIME_ENV,
     };
     use std::{
         ffi::OsString,
@@ -513,6 +544,32 @@ mod tests {
     fn test_link_flags_path_for() {
         let path = link_flags_path_for(Path::new("/tmp/libeunomia.a"));
         assert_eq!(path, Path::new("/tmp/libeunomia.a.linkflags"));
+    }
+
+    #[test]
+    fn test_select_runtime_resolution_prefers_installed_runtime_over_checkout_fallbacks() {
+        let temp_dir = TempDir::new().unwrap();
+        let installed_runtime = temp_dir.path().join("installed/libeunomia.a");
+        let checkout_root = temp_dir.path().join("repo-root");
+
+        fs::create_dir_all(installed_runtime.parent().unwrap()).unwrap();
+        fs::write(&installed_runtime, "").unwrap();
+        fs::create_dir_all(&checkout_root).unwrap();
+
+        let selection = select_runtime_resolution(
+            None,
+            None,
+            vec![installed_runtime.clone()],
+            vec![checkout_root],
+        )
+        .unwrap();
+
+        match selection {
+            RuntimeSelection::ExistingLibrary(path) => assert_eq!(path, installed_runtime),
+            RuntimeSelection::CheckoutRoots(_) => {
+                panic!("installed runtime should win before checkout fallback")
+            }
+        }
     }
 
     #[test]

--- a/compiler/cmd/src/bpf_compiler/standalone.rs
+++ b/compiler/cmd/src/bpf_compiler/standalone.rs
@@ -15,6 +15,7 @@ use anyhow::{anyhow, bail, Context, Result};
 use log::{debug, info};
 
 const STANDALONE_RUNTIME_ENV: &str = "EUNOMIA_STANDALONE_LIB";
+const CHECKOUT_RUNTIME_TARGET_DIR: &str = "bpf-loader-rs/target/eunomia-standalone-runtime";
 const DEFAULT_NATIVE_LINK_ARGS: &[&str] = &[
     "-lelf",
     "-lz",
@@ -72,25 +73,15 @@ fn parse_native_link_args(raw: &str) -> Option<Vec<String>> {
 }
 
 fn normalize_native_link_args(flags: Vec<String>) -> Vec<String> {
-    let mut normalized = Vec::new();
-    for flag in flags {
-        if flag.is_empty() || flag == "-lgcc_s" {
-            continue;
-        }
-        if !normalized.iter().any(|existing| existing == &flag) {
-            normalized.push(flag);
-        }
-    }
-    normalized
+    flags
+        .into_iter()
+        .filter(|flag| !flag.is_empty() && flag != "-lgcc_s")
+        .collect()
 }
 
 fn merge_native_link_args(base: Vec<String>, extra: Vec<String>) -> Vec<String> {
     let mut merged = base;
-    for flag in extra {
-        if !merged.iter().any(|existing| existing == &flag) {
-            merged.push(flag);
-        }
-    }
+    merged.extend(extra);
     merged
 }
 
@@ -187,7 +178,6 @@ fn checkout_roots() -> Vec<PathBuf> {
     let mut roots = Vec::new();
 
     for start in [
-        Some(PathBuf::from(env!("CARGO_MANIFEST_DIR"))),
         env::current_dir().ok(),
         env::current_exe()
             .ok()
@@ -201,22 +191,6 @@ fn checkout_roots() -> Vec<PathBuf> {
         }
     }
     roots
-}
-
-fn add_checkout_runtime_candidates(candidates: &mut Vec<PathBuf>, checkout_root: &Path) {
-    let target_dir = checkout_root.join("bpf-loader-rs/target");
-    push_candidate(candidates, target_dir.join("release/libeunomia.a"));
-    push_candidate(candidates, target_dir.join("debug/libeunomia.a"));
-
-    if let Ok(entries) = fs::read_dir(&target_dir) {
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if path.is_dir() {
-                push_candidate(candidates, path.join("release/libeunomia.a"));
-                push_candidate(candidates, path.join("debug/libeunomia.a"));
-            }
-        }
-    }
 }
 
 fn installed_runtime_candidates() -> Vec<PathBuf> {
@@ -242,20 +216,13 @@ fn installed_runtime_candidates() -> Vec<PathBuf> {
     candidates
 }
 
-fn checkout_runtime_candidates() -> Vec<PathBuf> {
-    let mut candidates = Vec::new();
-
-    for checkout_root in checkout_roots() {
-        add_checkout_runtime_candidates(&mut candidates, &checkout_root);
-    }
-
-    debug!("Checkout standalone runtime search paths: {:?}", candidates);
-
-    candidates
+fn checkout_runtime_build_dir(checkout_root: &Path) -> PathBuf {
+    checkout_root.join(CHECKOUT_RUNTIME_TARGET_DIR)
 }
 
 fn build_runtime_from_checkout(checkout_root: &Path) -> Result<StandaloneRuntime> {
     let manifest_path = checkout_root.join("bpf-loader-rs/Cargo.toml");
+    let target_dir = checkout_runtime_build_dir(checkout_root);
     info!(
         "Building standalone runtime from {}",
         manifest_path.display()
@@ -267,6 +234,8 @@ fn build_runtime_from_checkout(checkout_root: &Path) -> Result<StandaloneRuntime
         .arg(&manifest_path)
         .arg("-p")
         .arg("bpf-loader-c-wrapper")
+        .arg("--target-dir")
+        .arg(&target_dir)
         .arg("--release")
         .arg("--")
         .arg("--print=native-static-libs")
@@ -289,7 +258,7 @@ fn build_runtime_from_checkout(checkout_root: &Path) -> Result<StandaloneRuntime
     let native_link_args =
         finalize_native_link_args(parse_native_link_args(&combined_output).unwrap_or_default())?;
 
-    let library_path = checkout_root.join("bpf-loader-rs/target/release/libeunomia.a");
+    let library_path = target_dir.join("release/libeunomia.a");
     if !library_path.exists() {
         bail!(
             "Built standalone runtime but `{}` was not produced",
@@ -324,25 +293,28 @@ fn resolve_standalone_runtime() -> Result<StandaloneRuntime> {
         return standalone_runtime_from_library_path(explicit_path);
     }
 
-    let checkout_candidates = checkout_runtime_candidates();
-    if let Some(path) = checkout_candidates.into_iter().find(|path| path.exists()) {
-        return standalone_runtime_from_library_path(path);
-    }
-
     let mut build_error = None;
     for checkout_root in checkout_roots() {
         match build_runtime_from_checkout(&checkout_root) {
             Ok(runtime) => return Ok(runtime),
-            Err(err) => build_error = Some(err),
+            Err(err) => {
+                debug!(
+                    "Failed to build checkout standalone runtime from {}: {}",
+                    checkout_root.display(),
+                    err
+                );
+                build_error = Some(err);
+            }
         }
-    }
-    if let Some(err) = build_error {
-        return Err(err);
     }
 
     let installed_candidates = installed_runtime_candidates();
     if let Some(path) = installed_candidates.into_iter().find(|path| path.exists()) {
         return standalone_runtime_from_library_path(path);
+    }
+
+    if let Some(err) = build_error {
+        return Err(err);
     }
 
     bail!(
@@ -393,7 +365,7 @@ pub(crate) fn build_standalone_executable(opts: &Options) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::{
-        add_checkout_runtime_candidates, find_checkout_root, link_flags_path_for,
+        checkout_runtime_build_dir, find_checkout_root, link_flags_path_for,
         merge_native_link_args, normalize_native_link_args, parse_native_link_args,
     };
     use std::{fs, path::Path};
@@ -419,7 +391,7 @@ mod tests {
                 "-lz".to_string(),
                 "-lelf".to_string(),
             ]),
-            vec!["-lelf", "-lz"]
+            vec!["-lelf", "-lz", "-lelf"]
         );
     }
 
@@ -434,7 +406,7 @@ mod tests {
                     "-llzma".to_string()
                 ],
             ),
-            vec!["-lelf", "-lz", "-lzstd", "-llzma"]
+            vec!["-lelf", "-lz", "-lz", "-lzstd", "-llzma"]
         );
     }
 
@@ -452,23 +424,13 @@ mod tests {
     }
 
     #[test]
-    fn test_add_checkout_runtime_candidates() {
+    fn test_checkout_runtime_build_dir() {
         let temp_dir = TempDir::new().unwrap();
         let repo_root = temp_dir.path();
-        let target_dir = repo_root.join("bpf-loader-rs/target/x86_64-unknown-linux-gnu");
-        fs::create_dir_all(target_dir.join("release")).unwrap();
-
-        let mut candidates = Vec::new();
-        add_checkout_runtime_candidates(&mut candidates, repo_root);
-
-        assert!(candidates.iter().any(|candidate| {
-            candidate == &repo_root.join("bpf-loader-rs/target/release/libeunomia.a")
-        }));
-        assert!(candidates.iter().any(|candidate| {
-            candidate
-                == &repo_root
-                    .join("bpf-loader-rs/target/x86_64-unknown-linux-gnu/release/libeunomia.a")
-        }));
+        assert_eq!(
+            checkout_runtime_build_dir(repo_root),
+            repo_root.join("bpf-loader-rs/target/eunomia-standalone-runtime")
+        );
     }
 
     #[test]

--- a/compiler/cmd/src/bpf_compiler/standalone.rs
+++ b/compiler/cmd/src/bpf_compiler/standalone.rs
@@ -5,6 +5,7 @@
 //!
 use std::{
     env, fs,
+    io::ErrorKind,
     path::{Path, PathBuf},
     process::Command,
 };
@@ -83,6 +84,56 @@ fn normalize_native_link_args(flags: Vec<String>) -> Vec<String> {
     normalized
 }
 
+fn merge_native_link_args(base: Vec<String>, extra: Vec<String>) -> Vec<String> {
+    let mut merged = base;
+    for flag in extra {
+        if !merged.iter().any(|existing| existing == &flag) {
+            merged.push(flag);
+        }
+    }
+    merged
+}
+
+fn pkg_config_static_link_args() -> Result<Option<Vec<String>>> {
+    let output = match Command::new("pkg-config")
+        .arg("--static")
+        .arg("--libs")
+        .args(["libelf", "zlib"])
+        .output()
+    {
+        Ok(output) => output,
+        Err(err) if err.kind() == ErrorKind::NotFound => return Ok(None),
+        Err(err) => {
+            return Err(err)
+                .with_context(|| anyhow!("Failed to invoke pkg-config for standalone runtime"))
+        }
+    };
+    if !output.status.success() {
+        debug!(
+            "pkg-config --static --libs libelf zlib failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        return Ok(None);
+    }
+
+    let link_args = String::from_utf8_lossy(&output.stdout)
+        .split_whitespace()
+        .map(|flag| flag.trim().to_string())
+        .collect::<Vec<_>>();
+    Ok(Some(normalize_native_link_args(link_args)))
+}
+
+fn finalize_native_link_args(flags: Vec<String>) -> Result<Vec<String>> {
+    let mut finalized = normalize_native_link_args(flags);
+    if let Some(pkg_config_args) = pkg_config_static_link_args()? {
+        finalized = merge_native_link_args(finalized, pkg_config_args);
+    }
+    if finalized.is_empty() {
+        bail!("No standalone runtime link flags were resolved");
+    }
+    Ok(finalized)
+}
+
 fn read_link_flags_file(library_path: &Path) -> Result<Option<Vec<String>>> {
     let link_flags_path = link_flags_path_for(library_path);
     if !link_flags_path.exists() {
@@ -98,26 +149,23 @@ fn read_link_flags_file(library_path: &Path) -> Result<Option<Vec<String>>> {
         .split_whitespace()
         .map(|flag| flag.trim().to_string())
         .collect::<Vec<_>>();
-    let flags = normalize_native_link_args(flags);
-    if flags.is_empty() {
-        bail!(
-            "Standalone runtime link flags file {:?} is empty",
-            link_flags_path
-        );
-    }
-    Ok(Some(flags))
+    Ok(Some(finalize_native_link_args(flags)?))
 }
 
-fn default_native_link_args() -> Vec<String> {
-    DEFAULT_NATIVE_LINK_ARGS
-        .iter()
-        .map(|flag| flag.to_string())
-        .collect()
+fn default_native_link_args() -> Result<Vec<String>> {
+    finalize_native_link_args(
+        DEFAULT_NATIVE_LINK_ARGS
+            .iter()
+            .map(|flag| flag.to_string())
+            .collect(),
+    )
 }
 
 fn standalone_runtime_from_library_path(library_path: PathBuf) -> Result<StandaloneRuntime> {
-    let native_link_args =
-        read_link_flags_file(&library_path)?.unwrap_or_else(default_native_link_args);
+    let native_link_args = match read_link_flags_file(&library_path)? {
+        Some(link_args) => link_args,
+        None => default_native_link_args()?,
+    };
     Ok(StandaloneRuntime {
         library_path,
         native_link_args,
@@ -171,7 +219,7 @@ fn add_checkout_runtime_candidates(candidates: &mut Vec<PathBuf>, checkout_root:
     }
 }
 
-fn bundled_runtime_candidates() -> Vec<PathBuf> {
+fn installed_runtime_candidates() -> Vec<PathBuf> {
     let mut candidates = Vec::new();
 
     if let Ok(current_exe) = env::current_exe() {
@@ -186,11 +234,22 @@ fn bundled_runtime_candidates() -> Vec<PathBuf> {
         add_install_layout_candidates(&mut candidates, &eunomia_home);
     }
 
+    debug!(
+        "Installed standalone runtime search paths: {:?}",
+        candidates
+    );
+
+    candidates
+}
+
+fn checkout_runtime_candidates() -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+
     for checkout_root in checkout_roots() {
         add_checkout_runtime_candidates(&mut candidates, &checkout_root);
     }
 
-    debug!("Standalone runtime search paths: {:?}", candidates);
+    debug!("Checkout standalone runtime search paths: {:?}", candidates);
 
     candidates
 }
@@ -228,7 +287,7 @@ fn build_runtime_from_checkout(checkout_root: &Path) -> Result<StandaloneRuntime
 
     let combined_output = format!("{stdout}\n{stderr}");
     let native_link_args =
-        parse_native_link_args(&combined_output).unwrap_or_else(default_native_link_args);
+        finalize_native_link_args(parse_native_link_args(&combined_output).unwrap_or_default())?;
 
     let library_path = checkout_root.join("bpf-loader-rs/target/release/libeunomia.a");
     if !library_path.exists() {
@@ -265,8 +324,8 @@ fn resolve_standalone_runtime() -> Result<StandaloneRuntime> {
         return standalone_runtime_from_library_path(explicit_path);
     }
 
-    let candidates = bundled_runtime_candidates();
-    if let Some(path) = candidates.into_iter().find(|path| path.exists()) {
+    let checkout_candidates = checkout_runtime_candidates();
+    if let Some(path) = checkout_candidates.into_iter().find(|path| path.exists()) {
         return standalone_runtime_from_library_path(path);
     }
 
@@ -279,6 +338,11 @@ fn resolve_standalone_runtime() -> Result<StandaloneRuntime> {
     }
     if let Some(err) = build_error {
         return Err(err);
+    }
+
+    let installed_candidates = installed_runtime_candidates();
+    if let Some(path) = installed_candidates.into_iter().find(|path| path.exists()) {
+        return standalone_runtime_from_library_path(path);
     }
 
     bail!(
@@ -330,7 +394,7 @@ pub(crate) fn build_standalone_executable(opts: &Options) -> Result<()> {
 mod tests {
     use super::{
         add_checkout_runtime_candidates, find_checkout_root, link_flags_path_for,
-        parse_native_link_args,
+        merge_native_link_args, normalize_native_link_args, parse_native_link_args,
     };
     use std::{fs, path::Path};
     use tempfile::TempDir;
@@ -343,6 +407,34 @@ mod tests {
         assert_eq!(
             parsed,
             vec!["-lelf", "-lz", "-lpthread", "-lm", "-ldl", "-lc"]
+        );
+    }
+
+    #[test]
+    fn test_normalize_native_link_args_filters_gcc_s() {
+        assert_eq!(
+            normalize_native_link_args(vec![
+                "-lelf".to_string(),
+                "-lgcc_s".to_string(),
+                "-lz".to_string(),
+                "-lelf".to_string(),
+            ]),
+            vec!["-lelf", "-lz"]
+        );
+    }
+
+    #[test]
+    fn test_merge_native_link_args_appends_missing_flags() {
+        assert_eq!(
+            merge_native_link_args(
+                vec!["-lelf".to_string(), "-lz".to_string()],
+                vec![
+                    "-lz".to_string(),
+                    "-lzstd".to_string(),
+                    "-llzma".to_string()
+                ],
+            ),
+            vec!["-lelf", "-lz", "-lzstd", "-llzma"]
         );
     }
 

--- a/compiler/cmd/src/bpf_compiler/standalone.rs
+++ b/compiler/cmd/src/bpf_compiler/standalone.rs
@@ -3,11 +3,32 @@
 //! Copyright (c) 2023, eunomia-bpf
 //! All rights reserved.
 //!
-use std::process::Command;
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
 
 use crate::{config::Options, handle_std_command_with_log, helper::get_eunomia_data_dir};
 use anyhow::{anyhow, bail, Context, Result};
-use log::info;
+use log::{debug, info};
+
+const STANDALONE_RUNTIME_ENV: &str = "EUNOMIA_STANDALONE_LIB";
+const DEFAULT_NATIVE_LINK_ARGS: &[&str] = &[
+    "-lelf",
+    "-lz",
+    "-lutil",
+    "-lrt",
+    "-lpthread",
+    "-lm",
+    "-ldl",
+    "-lc",
+];
+
+struct StandaloneRuntime {
+    library_path: PathBuf,
+    native_link_args: Vec<String>,
+}
 
 fn num_to_hex(v: u8) -> char {
     match v {
@@ -17,14 +38,258 @@ fn num_to_hex(v: u8) -> char {
     }
 }
 
+fn push_candidate(candidates: &mut Vec<PathBuf>, candidate: PathBuf) {
+    if !candidates.iter().any(|existing| existing == &candidate) {
+        candidates.push(candidate);
+    }
+}
+
+fn add_install_layout_candidates(candidates: &mut Vec<PathBuf>, root: &Path) {
+    push_candidate(candidates, root.join("libeunomia.a"));
+    push_candidate(candidates, root.join("lib/libeunomia.a"));
+}
+
+fn link_flags_path_for(library_path: &Path) -> PathBuf {
+    let file_name = library_path
+        .file_name()
+        .expect("library path should have a file name")
+        .to_string_lossy();
+    library_path.with_file_name(format!("{file_name}.linkflags"))
+}
+
+fn parse_native_link_args(raw: &str) -> Option<Vec<String>> {
+    raw.lines()
+        .find_map(|line| line.split_once("native-static-libs: "))
+        .map(|(_, flags)| {
+            flags
+                .split_whitespace()
+                .map(|flag| flag.trim().to_string())
+                .collect::<Vec<_>>()
+        })
+        .map(normalize_native_link_args)
+        .filter(|flags| !flags.is_empty())
+}
+
+fn normalize_native_link_args(flags: Vec<String>) -> Vec<String> {
+    let mut normalized = Vec::new();
+    for flag in flags {
+        if flag.is_empty() || flag == "-lgcc_s" {
+            continue;
+        }
+        if !normalized.iter().any(|existing| existing == &flag) {
+            normalized.push(flag);
+        }
+    }
+    normalized
+}
+
+fn read_link_flags_file(library_path: &Path) -> Result<Option<Vec<String>>> {
+    let link_flags_path = link_flags_path_for(library_path);
+    if !link_flags_path.exists() {
+        return Ok(None);
+    }
+    let flags = fs::read_to_string(&link_flags_path).with_context(|| {
+        anyhow!(
+            "Failed to read standalone runtime link flags from {:?}",
+            link_flags_path
+        )
+    })?;
+    let flags = flags
+        .split_whitespace()
+        .map(|flag| flag.trim().to_string())
+        .collect::<Vec<_>>();
+    let flags = normalize_native_link_args(flags);
+    if flags.is_empty() {
+        bail!(
+            "Standalone runtime link flags file {:?} is empty",
+            link_flags_path
+        );
+    }
+    Ok(Some(flags))
+}
+
+fn default_native_link_args() -> Vec<String> {
+    DEFAULT_NATIVE_LINK_ARGS
+        .iter()
+        .map(|flag| flag.to_string())
+        .collect()
+}
+
+fn standalone_runtime_from_library_path(library_path: PathBuf) -> Result<StandaloneRuntime> {
+    let native_link_args =
+        read_link_flags_file(&library_path)?.unwrap_or_else(default_native_link_args);
+    Ok(StandaloneRuntime {
+        library_path,
+        native_link_args,
+    })
+}
+
+fn find_checkout_root(start: &Path) -> Option<PathBuf> {
+    for candidate in start.ancestors() {
+        if candidate.join("bpf-loader-rs/Cargo.toml").is_file()
+            && candidate.join("compiler/cmd/Cargo.toml").is_file()
+        {
+            return Some(candidate.to_path_buf());
+        }
+    }
+    None
+}
+
+fn checkout_roots() -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+
+    for start in [
+        Some(PathBuf::from(env!("CARGO_MANIFEST_DIR"))),
+        env::current_dir().ok(),
+        env::current_exe()
+            .ok()
+            .and_then(|path| path.parent().map(Path::to_path_buf)),
+    ]
+    .into_iter()
+    .flatten()
+    {
+        if let Some(root) = find_checkout_root(&start) {
+            push_candidate(&mut roots, root);
+        }
+    }
+    roots
+}
+
+fn add_checkout_runtime_candidates(candidates: &mut Vec<PathBuf>, checkout_root: &Path) {
+    let target_dir = checkout_root.join("bpf-loader-rs/target");
+    push_candidate(candidates, target_dir.join("release/libeunomia.a"));
+    push_candidate(candidates, target_dir.join("debug/libeunomia.a"));
+
+    if let Ok(entries) = fs::read_dir(&target_dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                push_candidate(candidates, path.join("release/libeunomia.a"));
+                push_candidate(candidates, path.join("debug/libeunomia.a"));
+            }
+        }
+    }
+}
+
+fn bundled_runtime_candidates() -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+
+    if let Ok(current_exe) = env::current_exe() {
+        if let Some(current_exe_dir) = current_exe.parent() {
+            for ancestor in current_exe_dir.ancestors() {
+                add_install_layout_candidates(&mut candidates, ancestor);
+            }
+        }
+    }
+
+    if let Ok(eunomia_home) = get_eunomia_data_dir() {
+        add_install_layout_candidates(&mut candidates, &eunomia_home);
+    }
+
+    for checkout_root in checkout_roots() {
+        add_checkout_runtime_candidates(&mut candidates, &checkout_root);
+    }
+
+    debug!("Standalone runtime search paths: {:?}", candidates);
+
+    candidates
+}
+
+fn build_runtime_from_checkout(checkout_root: &Path) -> Result<StandaloneRuntime> {
+    let manifest_path = checkout_root.join("bpf-loader-rs/Cargo.toml");
+    info!(
+        "Building standalone runtime from {}",
+        manifest_path.display()
+    );
+
+    let output = Command::new("cargo")
+        .arg("rustc")
+        .arg("--manifest-path")
+        .arg(&manifest_path)
+        .arg("-p")
+        .arg("bpf-loader-c-wrapper")
+        .arg("--release")
+        .arg("--")
+        .arg("--print=native-static-libs")
+        .output()
+        .with_context(|| anyhow!("Failed to invoke cargo to build standalone runtime"))?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    if !output.status.success() {
+        log::info!("$ cargo rustc --manifest-path {:?} -p bpf-loader-c-wrapper --release -- --print=native-static-libs", manifest_path);
+        log::info!("{stdout}");
+        log::error!("{stderr}");
+        bail!(
+            "Failed to build standalone runtime (exit code = {:?})",
+            output.status.code()
+        );
+    }
+
+    let combined_output = format!("{stdout}\n{stderr}");
+    let native_link_args =
+        parse_native_link_args(&combined_output).unwrap_or_else(default_native_link_args);
+
+    let library_path = checkout_root.join("bpf-loader-rs/target/release/libeunomia.a");
+    if !library_path.exists() {
+        bail!(
+            "Built standalone runtime but `{}` was not produced",
+            library_path.display()
+        );
+    }
+
+    let link_flags_path = link_flags_path_for(&library_path);
+    fs::write(&link_flags_path, native_link_args.join(" ")).with_context(|| {
+        anyhow!(
+            "Failed to write standalone runtime link flags to {}",
+            link_flags_path.display()
+        )
+    })?;
+
+    Ok(StandaloneRuntime {
+        library_path,
+        native_link_args,
+    })
+}
+
+fn resolve_standalone_runtime() -> Result<StandaloneRuntime> {
+    if let Ok(explicit_path) = env::var(STANDALONE_RUNTIME_ENV) {
+        let explicit_path = PathBuf::from(explicit_path);
+        if !explicit_path.exists() {
+            bail!(
+                "`{}` points to `{}`, but that file does not exist",
+                STANDALONE_RUNTIME_ENV,
+                explicit_path.display()
+            );
+        }
+        return standalone_runtime_from_library_path(explicit_path);
+    }
+
+    let candidates = bundled_runtime_candidates();
+    if let Some(path) = candidates.into_iter().find(|path| path.exists()) {
+        return standalone_runtime_from_library_path(path);
+    }
+
+    let mut build_error = None;
+    for checkout_root in checkout_roots() {
+        match build_runtime_from_checkout(&checkout_root) {
+            Ok(runtime) => return Ok(runtime),
+            Err(err) => build_error = Some(err),
+        }
+    }
+    if let Some(err) = build_error {
+        return Err(err);
+    }
+
+    bail!(
+        "Failed to locate `libeunomia.a` for `--standalone`. Install `ecc` via `make -C compiler install`, or build the runtime with `cargo rustc --manifest-path bpf-loader-rs/Cargo.toml -p bpf-loader-c-wrapper --release -- --print=native-static-libs`."
+    );
+}
+
 pub(crate) fn build_standalone_executable(opts: &Options) -> Result<()> {
     info!("Generating standalone executable..");
     let template_source = include_str!("standalone_bpf_loader.template.c");
-
-    let libeunomia_path = get_eunomia_data_dir()?.join("libeunomia.a");
-    if !libeunomia_path.exists() {
-        bail!("`{:?}` does not exist, fetch one from https://github.com/eunomia-bpf/eunomia-bpf/actions",libeunomia_path);
-    }
+    let runtime = resolve_standalone_runtime()?;
     let package_json_content = std::fs::read_to_string(opts.get_output_package_config_path())
         .with_context(|| anyhow!("Failed to read package json"))?;
     let bytes_str = package_json_content
@@ -52,10 +317,71 @@ pub(crate) fn build_standalone_executable(opts: &Options) -> Result<()> {
         .arg("-O2")
         .arg("-static")
         .arg(source_path)
-        .arg(libeunomia_path)
+        .arg(&runtime.library_path)
+        .args(&runtime.native_link_args)
         .arg("-o")
         .arg(&executable_path);
     handle_std_command_with_log!(cmd, "Failed to build the standalone executable");
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        add_checkout_runtime_candidates, find_checkout_root, link_flags_path_for,
+        parse_native_link_args,
+    };
+    use std::{fs, path::Path};
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_parse_native_link_args() {
+        let parsed =
+            parse_native_link_args("note: native-static-libs: -lelf -lz -lpthread -lm -ldl -lc")
+                .unwrap();
+        assert_eq!(
+            parsed,
+            vec!["-lelf", "-lz", "-lpthread", "-lm", "-ldl", "-lc"]
+        );
+    }
+
+    #[test]
+    fn test_find_checkout_root() {
+        let temp_dir = TempDir::new().unwrap();
+        let repo_root = temp_dir.path();
+        fs::create_dir_all(repo_root.join("bpf-loader-rs")).unwrap();
+        fs::create_dir_all(repo_root.join("compiler/cmd/src")).unwrap();
+        fs::write(repo_root.join("bpf-loader-rs/Cargo.toml"), "[workspace]\n").unwrap();
+        fs::write(repo_root.join("compiler/cmd/Cargo.toml"), "[package]\n").unwrap();
+
+        let nested = repo_root.join("compiler/cmd/src");
+        assert_eq!(find_checkout_root(&nested).as_deref(), Some(repo_root));
+    }
+
+    #[test]
+    fn test_add_checkout_runtime_candidates() {
+        let temp_dir = TempDir::new().unwrap();
+        let repo_root = temp_dir.path();
+        let target_dir = repo_root.join("bpf-loader-rs/target/x86_64-unknown-linux-gnu");
+        fs::create_dir_all(target_dir.join("release")).unwrap();
+
+        let mut candidates = Vec::new();
+        add_checkout_runtime_candidates(&mut candidates, repo_root);
+
+        assert!(candidates.iter().any(|candidate| {
+            candidate == &repo_root.join("bpf-loader-rs/target/release/libeunomia.a")
+        }));
+        assert!(candidates.iter().any(|candidate| {
+            candidate
+                == &repo_root
+                    .join("bpf-loader-rs/target/x86_64-unknown-linux-gnu/release/libeunomia.a")
+        }));
+    }
+
+    #[test]
+    fn test_link_flags_path_for() {
+        let path = link_flags_path_for(Path::new("/tmp/libeunomia.a"));
+        assert_eq!(path, Path::new("/tmp/libeunomia.a.linkflags"));
+    }
 }

--- a/compiler/cmd/src/bpf_compiler/standalone.rs
+++ b/compiler/cmd/src/bpf_compiler/standalone.rs
@@ -245,18 +245,24 @@ fn checkout_roots() -> Vec<PathBuf> {
     roots
 }
 
-fn add_current_exe_runtime_candidates(candidates: &mut Vec<PathBuf>, current_exe: &Path) {
+fn add_current_exe_runtime_candidates(
+    primary_candidates: &mut Vec<PathBuf>,
+    fallback_candidates: &mut Vec<PathBuf>,
+    current_exe: &Path,
+) {
     let Some(current_exe_dir) = current_exe.parent() else {
         return;
     };
 
-    add_install_layout_candidates(candidates, current_exe_dir);
-
     if current_exe_dir.file_name() == Some(OsStr::new(BIN_DIR_NAME)) {
         if let Some(install_root) = current_exe_dir.parent() {
-            add_install_layout_candidates(candidates, install_root);
+            add_install_layout_candidates(primary_candidates, install_root);
         }
+        add_install_layout_candidates(fallback_candidates, current_exe_dir);
+        return;
     }
+
+    add_install_layout_candidates(primary_candidates, current_exe_dir);
 }
 
 fn installed_runtime_candidates_for(
@@ -264,14 +270,17 @@ fn installed_runtime_candidates_for(
     eunomia_home: Option<&Path>,
 ) -> Vec<PathBuf> {
     let mut candidates = Vec::new();
+    let mut fallback_candidates = Vec::new();
 
     if let Some(current_exe) = current_exe {
-        add_current_exe_runtime_candidates(&mut candidates, current_exe);
+        add_current_exe_runtime_candidates(&mut candidates, &mut fallback_candidates, current_exe);
     }
 
     if let Some(eunomia_home) = eunomia_home {
         add_install_layout_candidates(&mut candidates, eunomia_home);
     }
+
+    candidates.extend(fallback_candidates);
 
     candidates
 }
@@ -598,7 +607,7 @@ mod tests {
     }
 
     #[test]
-    fn test_installed_runtime_candidates_only_consider_current_bin_root_and_eunomia_home() {
+    fn test_installed_runtime_candidates_prefer_supported_install_layouts_before_bin_fallbacks() {
         let candidates = installed_runtime_candidates_for(
             Some(Path::new("/opt/eunomia/bin/ecc-rs")),
             Some(Path::new("/home/test/.local/share/eunomia")),
@@ -607,14 +616,41 @@ mod tests {
         assert_eq!(
             candidates,
             vec![
-                PathBuf::from("/opt/eunomia/bin/libeunomia.a"),
-                PathBuf::from("/opt/eunomia/bin/lib/libeunomia.a"),
                 PathBuf::from("/opt/eunomia/libeunomia.a"),
                 PathBuf::from("/opt/eunomia/lib/libeunomia.a"),
                 PathBuf::from("/home/test/.local/share/eunomia/libeunomia.a"),
                 PathBuf::from("/home/test/.local/share/eunomia/lib/libeunomia.a"),
+                PathBuf::from("/opt/eunomia/bin/libeunomia.a"),
+                PathBuf::from("/opt/eunomia/bin/lib/libeunomia.a"),
             ]
         );
+    }
+
+    #[test]
+    fn test_select_runtime_resolution_prefers_supported_install_layouts_over_bin_fallbacks() {
+        let temp_dir = TempDir::new().unwrap();
+        let install_root = temp_dir.path().join("install-root");
+        let supported_runtime = install_root.join("libeunomia.a");
+        let bin_fallback = install_root.join("bin/libeunomia.a");
+
+        fs::create_dir_all(bin_fallback.parent().unwrap()).unwrap();
+        fs::write(&supported_runtime, "").unwrap();
+        fs::write(&bin_fallback, "").unwrap();
+
+        let selection = select_runtime_resolution(
+            None,
+            None,
+            installed_runtime_candidates_for(Some(&install_root.join("bin/ecc-rs")), None),
+            Vec::new(),
+        )
+        .unwrap();
+
+        match selection {
+            RuntimeSelection::ExistingLibrary(path) => assert_eq!(path, supported_runtime),
+            RuntimeSelection::CheckoutRoots(_) => {
+                panic!("supported install layout should win before bin-adjacent fallback")
+            }
+        }
     }
 
     #[test]

--- a/compiler/cmd/src/helper.rs
+++ b/compiler/cmd/src/helper.rs
@@ -65,6 +65,62 @@ pub fn get_target_arch() -> String {
     arch.to_string()
 }
 
+#[cfg(test)]
+mod tests {
+    use super::{get_eunomia_data_dir, EUNOMIA_HOME_ENV};
+    use std::{
+        ffi::OsString,
+        sync::{Mutex, OnceLock},
+    };
+    use tempfile::TempDir;
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    struct EnvGuard {
+        saved: Vec<(&'static str, Option<OsString>)>,
+    }
+
+    impl EnvGuard {
+        fn capture(keys: &[&'static str]) -> Self {
+            Self {
+                saved: keys
+                    .iter()
+                    .map(|key| (*key, std::env::var_os(key)))
+                    .collect(),
+            }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (key, value) in &self.saved {
+                match value {
+                    Some(value) => std::env::set_var(key, value),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_get_eunomia_data_dir_prefers_eunomia_home_env() {
+        let _lock = env_lock().lock().unwrap();
+        let _env = EnvGuard::capture(&[EUNOMIA_HOME_ENV, "XDG_DATA_HOME", "HOME"]);
+        let temp_dir = TempDir::new().unwrap();
+        let eunomia_home = temp_dir.path().join("custom-eunomia-home");
+        let xdg_data_home = temp_dir.path().join("xdg-data-home");
+
+        std::env::set_var(EUNOMIA_HOME_ENV, &eunomia_home);
+        std::env::set_var("XDG_DATA_HOME", &xdg_data_home);
+        std::env::remove_var("HOME");
+
+        assert_eq!(get_eunomia_data_dir().unwrap(), eunomia_home);
+    }
+}
+
 #[macro_export]
 macro_rules! handle_runscript_output {
     ($code:expr, $command:expr, $output:expr, $error: expr, $error_msg: literal) => {

--- a/compiler/dockerfile
+++ b/compiler/dockerfile
@@ -5,7 +5,7 @@ COPY . /usr/local/src
 
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
-        libelf1 libelf-dev zlib1g-dev libclang-13-dev \
+        libelf1 libelf-dev zlib1g-dev libzstd-dev liblzma-dev libclang-13-dev \
         make wget curl python2 clang llvm pkg-config build-essential git && \
     apt-get install -y --no-install-recommends ca-certificates	&& \
 	update-ca-certificates	&& \

--- a/ecli/Makefile
+++ b/ecli/Makefile
@@ -8,9 +8,8 @@ build:
 install:
 	rm -rf target/
 	cargo build --release
-	rm -rf $(EUNOMIA_HOME)
 	mkdir -p $(EUNOMIA_HOME)/bin
-	cp ./target/release/ecli-rs $(EUNOMIA_HOME)/bin/ecli
+	install -m 755 ./target/release/ecli-rs $(EUNOMIA_HOME)/bin/ecli
 
 install-deps:
 	sudo apt install libssl-dev

--- a/ecli/Makefile
+++ b/ecli/Makefile
@@ -1,5 +1,5 @@
 XDG_DATA_HOME ?= ${HOME}/.local/share
-EUNOMIA_HOME := $(XDG_DATA_HOME)/eunomia
+EUNOMIA_HOME ?= $(XDG_DATA_HOME)/eunomia
 
 .PHONY: build
 build:

--- a/examples/bpftools/sigsnoop/README.md
+++ b/examples/bpftools/sigsnoop/README.md
@@ -29,7 +29,7 @@ This example include a eBPF program and a WASM module in user space.
     ....
     ```
 
-- Install the `ecc` compiler-toolchain for compiling eBPF kernel code to a `config` file or `WASM` module(`clang`, `llvm`, and `libclang` should be installed for compiling), and install `struct-bindgen` for generating the export event header:
+- Install the `ecc` compiler-toolchain for compiling eBPF kernel code to a `config` file or `WASM` module(`clang`, `llvm`, `libclang`, and `pkg-config` should be installed for compiling), and install `struct-bindgen` for generating the export event header:
 
     ```console
     $ wget https://github.com/eunomia-bpf/eunomia-bpf/releases/latest/download/ecc && chmod +x ./ecc

--- a/flake.nix
+++ b/flake.nix
@@ -102,6 +102,53 @@
             hash = "sha256-CVEmKkzdFNLKCbcbeSIoM5QjYVLQglpz6gy7+ZFPgCY=";
           };
 
+          standaloneRuntime = pkgs.stdenv.mkDerivation (finalAttrs: {
+            pname = "ecc-standalone-runtime";
+            inherit version;
+            src = self;
+            cargoRoot = "bpf-loader-rs";
+            cargoDeps = pkgs.rustPlatform.importCargoLock {
+              lockFile = ./${finalAttrs.cargoRoot}/Cargo.lock;
+            };
+
+            nativeBuildInputs = with pkgs;[
+              pkg-config
+              cargoSetupHook
+              cargo
+              rustc
+            ];
+
+            buildInputs = with pkgs;[
+              elfutils
+              zlib
+              zlib.static
+            ];
+
+            preBuild = ''
+              cd ${finalAttrs.cargoRoot}
+            '';
+
+            buildPhase = ''
+              runHook preBuild
+              cargo rustc -p bpf-loader-c-wrapper --release -- --print=native-static-libs 2>&1 \
+                | awk -F 'native-static-libs: ' '/native-static-libs:/ { print $2 }' \
+                | awk 'BEGIN { first = 1 } { for (i = 1; i <= NF; i++) { if ($i != "-lgcc_s") { printf "%s%s", first ? "" : " ", $i; first = 0 } } } END { print "" }' \
+                > libeunomia.a.linkflags
+              test -s libeunomia.a.linkflags
+              test -f target/release/libeunomia.a
+              runHook postBuild
+            '';
+
+            installPhase = ''
+              runHook preInstall
+              install -Dm 644 target/release/libeunomia.a $out/lib/libeunomia.a
+              install -Dm 644 libeunomia.a.linkflags $out/lib/libeunomia.a.linkflags
+              runHook postInstall
+            '';
+
+            inherit meta;
+          });
+
           ecli = pkgs.stdenv.mkDerivation (finalAttrs: {
             name = "ecli";
             inherit version;
@@ -213,9 +260,13 @@
               };
 
               postInstall = ''
+                mkdir -p $out/lib
+                cp ${standaloneRuntime}/lib/libeunomia.a $out/lib/
+                cp ${standaloneRuntime}/lib/libeunomia.a.linkflags $out/lib/
                 wrapProgram $out/bin/ecc-rs \
                   --prefix LIBCLANG_PATH : ${llvmPackages.libclang.lib}/lib \
-                  --prefix PATH : ${lib.makeBinPath (with llvmPackages; [clang bintools-unwrapped])}
+                  --prefix PATH : ${lib.makeBinPath (with llvmPackages; [clang bintools-unwrapped])} \
+                  --prefix LIBRARY_PATH : ${lib.makeLibraryPath [ elfutils zlib.static ]}
               '';
 
               inherit meta;

--- a/flake.nix
+++ b/flake.nix
@@ -130,20 +130,21 @@
 
             buildPhase = ''
               runHook preBuild
-              ( cargo rustc -p bpf-loader-c-wrapper --release -- --print=native-static-libs 2>&1 \
+              mkdir -p target/eunomia-standalone-runtime/release
+              ( cargo rustc -p bpf-loader-c-wrapper --target-dir target/eunomia-standalone-runtime --release -- --print=native-static-libs 2>&1 \
                 | awk -F 'native-static-libs: ' '/native-static-libs:/ { print $2 }'; \
                 pkg-config --static --libs libelf zlib 2>/dev/null || true ) \
-                | awk 'BEGIN { first = 1 } { for (i = 1; i <= NF; i++) { if ($i != "-lgcc_s") { printf "%s%s", first ? "" : " ", $i; first = 0 } } } END { print "" }' \
-                > libeunomia.a.linkflags
-              test -s libeunomia.a.linkflags
-              test -f target/release/libeunomia.a
+                | awk '{ for (i = 1; i <= NF; i++) { if ($i != "-lgcc_s") { printf "%s ", $i } } } END { print "" }' \
+                > target/eunomia-standalone-runtime/release/libeunomia.a.linkflags
+              test -s target/eunomia-standalone-runtime/release/libeunomia.a.linkflags
+              test -f target/eunomia-standalone-runtime/release/libeunomia.a
               runHook postBuild
             '';
 
             installPhase = ''
               runHook preInstall
-              install -Dm 644 target/release/libeunomia.a $out/lib/libeunomia.a
-              install -Dm 644 libeunomia.a.linkflags $out/lib/libeunomia.a.linkflags
+              install -Dm 644 target/eunomia-standalone-runtime/release/libeunomia.a $out/lib/libeunomia.a
+              install -Dm 644 target/eunomia-standalone-runtime/release/libeunomia.a.linkflags $out/lib/libeunomia.a.linkflags
               runHook postInstall
             '';
 

--- a/flake.nix
+++ b/flake.nix
@@ -122,6 +122,8 @@
               elfutils
               zlib
               zlib.static
+              zstd
+              xz
             ];
 
             preBuild = ''
@@ -175,6 +177,8 @@
               zlib.static
               elfutils
               zlib
+              zstd
+              xz
               openssl.dev
               llvmPackages.bintools
             ];
@@ -268,7 +272,7 @@
                 wrapProgram $out/bin/ecc-rs \
                   --prefix LIBCLANG_PATH : ${llvmPackages.libclang.lib}/lib \
                   --prefix PATH : ${lib.makeBinPath (with llvmPackages; [clang bintools-unwrapped])} \
-                  --prefix LIBRARY_PATH : ${lib.makeLibraryPath [ elfutils zlib.static ]}
+                  --prefix LIBRARY_PATH : ${lib.makeLibraryPath [ elfutils zlib.static zstd xz ]}
               '';
 
               inherit meta;

--- a/flake.nix
+++ b/flake.nix
@@ -130,8 +130,9 @@
 
             buildPhase = ''
               runHook preBuild
-              cargo rustc -p bpf-loader-c-wrapper --release -- --print=native-static-libs 2>&1 \
-                | awk -F 'native-static-libs: ' '/native-static-libs:/ { print $2 }' \
+              ( cargo rustc -p bpf-loader-c-wrapper --release -- --print=native-static-libs 2>&1 \
+                | awk -F 'native-static-libs: ' '/native-static-libs:/ { print $2 }'; \
+                pkg-config --static --libs libelf zlib 2>/dev/null || true ) \
                 | awk 'BEGIN { first = 1 } { for (i = 1; i <= NF; i++) { if ($i != "-lgcc_s") { printf "%s%s", first ? "" : " ", $i; first = 0 } } } END { print "" }' \
                 > libeunomia.a.linkflags
               test -s libeunomia.a.linkflags

--- a/tests/release-flow.sh
+++ b/tests/release-flow.sh
@@ -120,16 +120,25 @@ make_failing_mv() {
 set -euo pipefail
 
 marker=${MV_FAIL_MARKER:?}
+mode=${MV_FAIL_MODE:-runtime-promotion}
 args=("$@")
 
 if [ "${#args[@]}" -ge 2 ]; then
 	src="${args[$((${#args[@]} - 2))]}"
 	dest="${args[$((${#args[@]} - 1))]}"
 
-	if [ ! -e "$marker" ] && [[ "$src" == */.eunomia.release.*/eunomia ]] && [ "$dest" = "eunomia" ]; then
-		touch "$marker"
-		printf '%s\n' "simulated runtime promotion failure for $src -> $dest" >&2
-		exit 1
+	if [ ! -e "$marker" ]; then
+		if [ "$mode" = "runtime-promotion" ] && [[ "$src" == */.eunomia.release.*/eunomia ]] && [ "$dest" = "eunomia" ]; then
+			touch "$marker"
+			printf '%s\n' "simulated runtime promotion failure for $src -> $dest" >&2
+			exit 1
+		fi
+
+		if [ "$mode" = "archive-backup" ] && [ "$src" = "eunomia.tar.gz" ] && [[ "$dest" == ./.eunomia.previous.tar.gz.* ]]; then
+			touch "$marker"
+			printf '%s\n' "simulated archive backup failure for $src -> $dest" >&2
+			exit 1
+		fi
 	fi
 fi
 
@@ -145,7 +154,7 @@ test_release_restores_old_surface_when_runtime_swap_fails() {
 
 	make_failing_mv "$workspace/bin"
 
-	if PATH="$workspace/bin:$PATH" MV_FAIL_MARKER="$workspace/mv.failed" \
+	if PATH="$workspace/bin:$PATH" MV_FAIL_MARKER="$workspace/mv.failed" MV_FAIL_MODE=runtime-promotion \
 		make -s -C "$workspace" -f "$repo_root/Makefile" release; then
 		status=0
 	else
@@ -206,6 +215,36 @@ test_release_preserves_new_runtime_when_backup_cleanup_fails() {
 	fi
 }
 
+test_release_restores_old_surfaces_when_archive_backup_fails() {
+	local workspace status
+	workspace="$(make_fixture)"
+	trap 'rm -rf "$workspace"' RETURN
+
+	make_failing_mv "$workspace/bin"
+
+	if PATH="$workspace/bin:$PATH" MV_FAIL_MARKER="$workspace/mv-archive.failed" MV_FAIL_MODE=archive-backup \
+		make -s -C "$workspace" -f "$repo_root/Makefile" release; then
+		status=0
+	else
+		status=$?
+	fi
+
+	if [ "$status" -eq 0 ]; then
+		printf 'expected release to fail when archive backup fails\n' >&2
+		return 1
+	fi
+
+	assert_file_content "$workspace/eunomia/release-id" "old-release"
+	assert_file_content "$workspace/eunomia/bin/ecli" "old-ecli"
+	test -f "$workspace/eunomia/legacy.txt"
+	test ! -e "$workspace/eunomia/bin/ecc"
+	test -f "$workspace/eunomia.tar.gz"
+	assert_tarball_matches_runtime "$workspace"
+	test -f "$workspace/mv-archive.failed"
+	assert_no_temp_roots "$workspace"
+}
+
 test_release_success
 test_release_restores_old_surface_when_runtime_swap_fails
 test_release_preserves_new_runtime_when_backup_cleanup_fails
+test_release_restores_old_surfaces_when_archive_backup_fails

--- a/tests/release-flow.sh
+++ b/tests/release-flow.sh
@@ -25,6 +25,7 @@ EOF
 	printf '%s\n' 'old-release' >"$workspace/eunomia/release-id"
 	printf '%s\n' 'legacy-runtime' >"$workspace/eunomia/legacy.txt"
 	printf '%s\n' 'old-ecli' >"$workspace/eunomia/bin/ecli"
+	tar -czf "$workspace/eunomia.tar.gz" -C "$workspace" eunomia
 
 	printf '%s\n' "$workspace"
 }
@@ -43,9 +44,24 @@ assert_no_temp_roots() {
 	local workspace=$1
 
 	if find "$workspace" -maxdepth 1 \( -name '.eunomia.release.*' -o -name '.eunomia.previous.*' \) | grep -q .; then
-		printf 'expected no leftover temporary release roots in %s\n' "$workspace" >&2
+		printf 'expected no leftover temporary release artifacts in %s\n' "$workspace" >&2
 		return 1
 	fi
+}
+
+assert_tarball_matches_runtime() {
+	local workspace=$1
+	local extract_root
+
+	extract_root="$(mktemp -d)"
+	tar -xzf "$workspace/eunomia.tar.gz" -C "$extract_root"
+	if ! diff -qr "$workspace/eunomia" "$extract_root/eunomia" >/dev/null; then
+		diff -qr "$workspace/eunomia" "$extract_root/eunomia" >&2 || true
+		rm -rf "$extract_root"
+		printf 'expected %s/eunomia.tar.gz to match %s/eunomia\n' "$workspace" "$workspace" >&2
+		return 1
+	fi
+	rm -rf "$extract_root"
 }
 
 test_release_success() {
@@ -60,6 +76,7 @@ test_release_success() {
 	assert_file_content "$workspace/eunomia/bin/ecc" "new-ecc"
 	test -f "$workspace/eunomia.tar.gz"
 	test ! -e "$workspace/eunomia/legacy.txt"
+	assert_tarball_matches_runtime "$workspace"
 	assert_no_temp_roots "$workspace"
 }
 
@@ -94,6 +111,62 @@ EOF
 	chmod +x "$wrapper_dir/rm"
 }
 
+make_failing_mv() {
+	local wrapper_dir=$1
+
+	mkdir -p "$wrapper_dir"
+	cat >"$wrapper_dir/mv" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+marker=${MV_FAIL_MARKER:?}
+args=("$@")
+
+if [ "${#args[@]}" -ge 2 ]; then
+	src="${args[$((${#args[@]} - 2))]}"
+	dest="${args[$((${#args[@]} - 1))]}"
+
+	if [ ! -e "$marker" ] && [[ "$src" == */.eunomia.release.*/eunomia ]] && [ "$dest" = "eunomia" ]; then
+		touch "$marker"
+		printf '%s\n' "simulated runtime promotion failure for $src -> $dest" >&2
+		exit 1
+	fi
+fi
+
+exec /bin/mv "$@"
+EOF
+	chmod +x "$wrapper_dir/mv"
+}
+
+test_release_restores_old_surface_when_runtime_swap_fails() {
+	local workspace status
+	workspace="$(make_fixture)"
+	trap 'rm -rf "$workspace"' RETURN
+
+	make_failing_mv "$workspace/bin"
+
+	if PATH="$workspace/bin:$PATH" MV_FAIL_MARKER="$workspace/mv.failed" \
+		make -s -C "$workspace" -f "$repo_root/Makefile" release; then
+		status=0
+	else
+		status=$?
+	fi
+
+	if [ "$status" -eq 0 ]; then
+		printf 'expected release to fail when runtime promotion fails\n' >&2
+		return 1
+	fi
+
+	assert_file_content "$workspace/eunomia/release-id" "old-release"
+	assert_file_content "$workspace/eunomia/bin/ecli" "old-ecli"
+	test -f "$workspace/eunomia/legacy.txt"
+	test ! -e "$workspace/eunomia/bin/ecc"
+	test -f "$workspace/eunomia.tar.gz"
+	assert_tarball_matches_runtime "$workspace"
+	test -f "$workspace/mv.failed"
+	assert_no_temp_roots "$workspace"
+}
+
 test_release_preserves_new_runtime_when_backup_cleanup_fails() {
 	local workspace status backup_root
 	workspace="$(make_fixture)"
@@ -118,6 +191,7 @@ test_release_preserves_new_runtime_when_backup_cleanup_fails() {
 	assert_file_content "$workspace/eunomia/bin/ecc" "new-ecc"
 	test -f "$workspace/eunomia.tar.gz"
 	test ! -e "$workspace/eunomia/legacy.txt"
+	assert_tarball_matches_runtime "$workspace"
 	test -f "$workspace/rm.failed"
 
 	backup_root="$(find "$workspace" -maxdepth 1 -type d -name '.eunomia.previous.*' -print -quit)"
@@ -126,11 +200,12 @@ test_release_preserves_new_runtime_when_backup_cleanup_fails() {
 		return 1
 	fi
 
-	if find "$workspace" -maxdepth 1 -type d -name '.eunomia.release.*' | grep -q .; then
-		printf 'expected release staging roots to be cleaned up after failure\n' >&2
+	if find "$workspace" -maxdepth 1 \( -name '.eunomia.release.*' -o -name '.eunomia.previous.tar.gz.*' \) | grep -q .; then
+		printf 'expected release staging roots and archive backups to be cleaned up after failure\n' >&2
 		return 1
 	fi
 }
 
 test_release_success
+test_release_restores_old_surface_when_runtime_swap_fails
 test_release_preserves_new_runtime_when_backup_cleanup_fails

--- a/tests/release-flow.sh
+++ b/tests/release-flow.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+make_fixture() {
+	local workspace
+	workspace="$(mktemp -d)"
+
+	mkdir -p "$workspace/ecli" "$workspace/compiler" "$workspace/eunomia/bin"
+
+	cat >"$workspace/ecli/Makefile" <<'EOF'
+install:
+	mkdir -p "$(EUNOMIA_HOME)/bin"
+	printf '%s\n' 'new-release' > "$(EUNOMIA_HOME)/release-id"
+	printf '%s\n' 'new-ecli' > "$(EUNOMIA_HOME)/bin/ecli"
+EOF
+
+	cat >"$workspace/compiler/Makefile" <<'EOF'
+install:
+	mkdir -p "$(EUNOMIA_HOME)/bin"
+	printf '%s\n' 'new-ecc' > "$(EUNOMIA_HOME)/bin/ecc"
+EOF
+
+	printf '%s\n' 'old-release' >"$workspace/eunomia/release-id"
+	printf '%s\n' 'legacy-runtime' >"$workspace/eunomia/legacy.txt"
+	printf '%s\n' 'old-ecli' >"$workspace/eunomia/bin/ecli"
+
+	printf '%s\n' "$workspace"
+}
+
+assert_file_content() {
+	local path=$1
+	local expected=$2
+
+	if ! grep -qxF "$expected" "$path"; then
+		printf 'expected %s to contain %s\n' "$path" "$expected" >&2
+		return 1
+	fi
+}
+
+assert_no_temp_roots() {
+	local workspace=$1
+
+	if find "$workspace" -maxdepth 1 \( -name '.eunomia.release.*' -o -name '.eunomia.previous.*' \) | grep -q .; then
+		printf 'expected no leftover temporary release roots in %s\n' "$workspace" >&2
+		return 1
+	fi
+}
+
+test_release_success() {
+	local workspace
+	workspace="$(make_fixture)"
+	trap 'rm -rf "$workspace"' RETURN
+
+	make -s -C "$workspace" -f "$repo_root/Makefile" release
+
+	assert_file_content "$workspace/eunomia/release-id" "new-release"
+	assert_file_content "$workspace/eunomia/bin/ecli" "new-ecli"
+	assert_file_content "$workspace/eunomia/bin/ecc" "new-ecc"
+	test -f "$workspace/eunomia.tar.gz"
+	test ! -e "$workspace/eunomia/legacy.txt"
+	assert_no_temp_roots "$workspace"
+}
+
+make_failing_rm() {
+	local wrapper_dir=$1
+
+	mkdir -p "$wrapper_dir"
+	cat >"$wrapper_dir/rm" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+marker=${RM_FAIL_MARKER:?}
+
+for arg in "$@"; do
+	case "$arg" in
+		*/.eunomia.previous.*)
+			if [ ! -e "$marker" ] && [ -d "$arg" ]; then
+				touch "$marker"
+				first_entry="$(find "$arg" -mindepth 1 -maxdepth 1 | head -n 1 || true)"
+				if [ -n "$first_entry" ]; then
+					/bin/rm -rf "$first_entry"
+				fi
+				printf '%s\n' "simulated partial backup deletion for $arg" >&2
+				exit 1
+			fi
+			;;
+	esac
+done
+
+exec /bin/rm "$@"
+EOF
+	chmod +x "$wrapper_dir/rm"
+}
+
+test_release_preserves_new_runtime_when_backup_cleanup_fails() {
+	local workspace status backup_root
+	workspace="$(make_fixture)"
+	trap 'rm -rf "$workspace"' RETURN
+
+	make_failing_rm "$workspace/bin"
+
+	if PATH="$workspace/bin:$PATH" RM_FAIL_MARKER="$workspace/rm.failed" \
+		make -s -C "$workspace" -f "$repo_root/Makefile" release; then
+		status=0
+	else
+		status=$?
+	fi
+
+	if [ "$status" -eq 0 ]; then
+		printf 'expected release to fail when backup cleanup fails\n' >&2
+		return 1
+	fi
+
+	assert_file_content "$workspace/eunomia/release-id" "new-release"
+	assert_file_content "$workspace/eunomia/bin/ecli" "new-ecli"
+	assert_file_content "$workspace/eunomia/bin/ecc" "new-ecc"
+	test -f "$workspace/eunomia.tar.gz"
+	test ! -e "$workspace/eunomia/legacy.txt"
+	test -f "$workspace/rm.failed"
+
+	backup_root="$(find "$workspace" -maxdepth 1 -type d -name '.eunomia.previous.*' -print -quit)"
+	if [ -z "$backup_root" ]; then
+		printf 'expected the partially deleted backup tree to remain for inspection\n' >&2
+		return 1
+	fi
+
+	if find "$workspace" -maxdepth 1 -type d -name '.eunomia.release.*' | grep -q .; then
+		printf 'expected release staging roots to be cleaned up after failure\n' >&2
+		return 1
+	fi
+}
+
+test_release_success
+test_release_preserves_new_runtime_when_backup_cleanup_fails


### PR DESCRIPTION
## Summary
- tighten standalone runtime selection and packaging so stale sidecars and unsupported lookup paths do not win
- make release staging and rollback preserve a consistent `eunomia` and `eunomia.tar.gz` surface across failure paths
- add focused regression coverage for the release-flow rollback cases

Closes #383